### PR TITLE
fix(tf): prewarm markdown cache in finalize (#1)

### DIFF
--- a/AIChat Watch App/ViewModels/ChatStore.swift
+++ b/AIChat Watch App/ViewModels/ChatStore.swift
@@ -2412,6 +2412,14 @@ final class ChatStore: ObservableObject {
                 // where the markdown renderer swaps in with stale plain text.
                 await streamingPacer.finalize()
 
+                // Prewarm the markdown cache BEFORE flipping status to .sent
+                // so that when ChatBubbleView swaps to AssistantMessageMarkdownView
+                // the prepared MarkdownContent is already available and the view
+                // skips the loading placeholder. Without this, a race between the
+                // status flip and the view's .task(id: text) can leave the bubble
+                // stuck on plain text. (Fixes #1)
+                await AssistantMessageMarkdownView.prewarmIfNeeded(for: snapshot.text)
+
                 upsertAssistantMessage(
                     id: assistantMessageID,
                     in: conversationID,


### PR DESCRIPTION
## Summary
- Calls `AssistantMessageMarkdownView.prewarmIfNeeded(for:)` inside `ChatStore.finalize()` before flipping `message.status` to `.sent`.
- Eliminates the race where the bubble swaps to `AssistantMessageMarkdownView` with `preparedContent == nil` and stays on the loading placeholder.

Fixes #1. Scheme A from the issue's "建议方案" section.

## Test plan
- [x] `xcodebuild -scheme "AIChat Watch App" -destination "generic/platform=watchOS" build`
- [x] `xcodebuild -scheme "AIChat Watch App" -destination "platform=watchOS Simulator,id=93A83695-2859-4388-B337-957616D03F55" test` — exit 0 (pre-existing first-attempt @MainActor segfaults and flakey UI test retries observed, overall pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)