### PR TITLE
ci(tf-react): move to GitHub Actions

### DIFF
--- a/.claude/routines/README.md
+++ b/.claude/routines/README.md
@@ -10,15 +10,16 @@ upload). This file covers the Routines side.
 
 ## Topology
 
-Three of the five prompts run as Claude Code Routines
-(cloud-hosted, event-triggered). The other two — `tf-autofix` and
-`tf-ship-finalize` — run as GitHub Actions workflows because they
-need the `check_run.completed` event that Routines does not expose.
+Two of the five prompts run as Claude Code Routines
+(cloud-hosted, event-triggered). The other three — `tf-react`,
+`tf-autofix`, and `tf-ship-finalize` — run as GitHub Actions workflows
+because they need events Routines does not expose: `issue_comment`
+(react) and `check_run.completed` (autofix, ship-finalize).
 
 | File | Runner | Trigger | Purpose |
 |---|---|---|---|
-| `tf-triage.md` | Routine | Schedule: every 30 min | Pull new TF feedback → file issues |
-| `tf-react.md`  | Routine | GitHub `issues` / `issue_comment` with label `source:testflight-api` | Process owner approvals / refinements |
+| `tf-triage.md` | Routine | Schedule: hourly (`0 * * * *` — Routines minimum) | Pull new TF feedback → file issues |
+| `tf-react.md`  | **GitHub Actions** (`.github/workflows/tf-react.yml`) | `issues.labeled` / `issues.closed` / `issue_comment.created` filtered by owner + `source:testflight-api` label | Process owner approvals / refinements |
 | `tf-autofix.md` | **GitHub Actions** (`.github/workflows/tf-autofix.yml`) | `issues.labeled` (`auto-fix-approved`) + `check_run.completed` on `autofix/issue-*` branches | Start, iterate, merge one fix |
 | `tf-ship.md` | Routine | GitHub `pull_request` closed + merged with PR label `auto-fix-ready` | Write WhatToTest → push main (no polling) |
 | `tf-ship-finalize.md` | **GitHub Actions** (`.github/workflows/tf-ship-finalize.yml`) | `check_run.completed` on `main` matching `Ship to TestFlight` | Close issues + clear `auto-fix-ready` after Xcode Cloud uploads |
@@ -55,15 +56,15 @@ the routine file in their "Assemble prompt" step.
    # → note the "Ship to TestFlight" workflow id
    ```
 
-4. **Create the 3 routines** at claude.ai/code/routines (`tf-triage`,
-   `tf-react`, `tf-ship`). For each:
+4. **Create the 2 routines** at claude.ai/code/routines (`tf-triage`,
+   `tf-ship`). For each:
    - Paste `_shared.md` content at the top of the prompt.
    - Append the routine file's content below.
    - Set the trigger per the table above.
    - Attach the built-in GitHub MCP connector.
 
-   `tf-autofix` and `tf-ship-finalize` are **not** created here —
-   both run from `.github/workflows/`. Install the Claude GitHub App
+   `tf-react`, `tf-autofix`, and `tf-ship-finalize` are **not** created
+   here — they run from `.github/workflows/`. Install the Claude GitHub App
    on the repo by running `/install-github-app` from Claude Code;
    that step also writes a `CLAUDE_CODE_OAUTH_TOKEN` repo secret
    (no Anthropic API key needed — it bills against your Claude
@@ -114,16 +115,26 @@ Subcommands:
 Dependencies: `pyjwt` + `cryptography`. `asc.py` auto-pip-installs
 them on first run if missing, so you don't need a pre-baked image.
 
-## Why tf-autofix lives in GitHub Actions
+## Why some routines live in GitHub Actions
 
-Claude Code Routines supports `pull_request`, `issues`,
-`issue_comment`, and `release` events. It does **not** expose
-`check_run` / `workflow_run` / `check_suite` events on the current
-tier — and that's exactly the signal Xcode Cloud emits when a PR
-build finishes. GitHub Actions does receive `check_run.completed`
-with sub-minute latency, so `tf-autofix` is wired there instead and
-re-fires itself naturally on every cloud build conclusion. No
-polling daemon, no label-toggle indirection.
+Claude Code Routines, on the current tier, supports `pull_request`,
+`issues`, and `release` events plus `schedule`. It does **not** expose:
+
+- `issue_comment` — the most ergonomic owner reply path (typing
+  `approve A` in a comment). Without it, only label changes / closures
+  are observable, which is fine for autofix gating but kills the
+  comment-driven react flow.
+- `check_run` / `workflow_run` / `check_suite` — the signal Xcode Cloud
+  emits when a build finishes. Without it, the autofix loop and
+  ship-finalize step have no native way to wake on cloud build outcomes.
+
+GitHub Actions receives all of these with sub-minute latency, so the
+prompts that need them (`tf-react`, `tf-autofix`, `tf-ship-finalize`)
+run there instead. Each Action assembles `_shared.md` + the routine
+prompt at job-start time and invokes
+[anthropics/claude-code-action](https://github.com/anthropics/claude-code-action)
+with the pre-minted `CLAUDE_CODE_OAUTH_TOKEN`. No polling daemon,
+no label-toggle indirection.
 
 ## Migration from the old local orchestrator
 

--- a/.claude/routines/tf-react.md
+++ b/.claude/routines/tf-react.md
@@ -1,15 +1,22 @@
 ---
 description: Process owner reactions on TF issues
-trigger: GitHub event (issues, issue_comment) filtered to label:source:testflight-api
+trigger: GitHub Actions (.github/workflows/tf-react.yml) — issues / issue_comment, owner-only, source:testflight-api
 ---
 
 You are the **REACT** routine. Follow `_shared.md`. One run processes
 one owner interaction (comment or label change) on one TF issue.
 
-The event payload tells you which issue was touched. Read it from the
-GitHub webhook context (`$ISSUE_NUMBER`, `$EVENT_ACTION`, `$COMMENT_BODY`,
-`$ACTOR`). Only act if `$ACTOR == hanbin2007` — events from the
-automation itself must not re-enter.
+This prompt runs from `tf-react.yml` (not Routines — Routines does not
+expose `issue_comment`). The workflow has already filtered on
+owner-sender + `source:testflight-api` label, so you can act
+unconditionally on these env vars:
+
+- `$EVENT_NAME` — `issues` or `issue_comment`
+- `$EVENT_ACTION` — `labeled` / `closed` for issues, `created` for issue_comment
+- `$ISSUE_NUMBER` — issue to operate on
+- `$LABEL_NAME` — populated only for `issues.labeled`
+- `$COMMENT_BODY` — populated only for `issue_comment.created`
+- `$ACTOR` — sender login (always the repo owner; pre-filtered)
 
 ## Steps
 
@@ -47,8 +54,11 @@ automation itself must not re-enter.
 
 ## Invariants
 
-- Never respond to comments from bots or from yourself. Filter on
-  `$ACTOR`.
+- The workflow already filtered out non-owner senders, non-TF issues,
+  and the `meta-state` issue. You can trust the inputs.
+- The `auto-fix-approved` label-add path is owned by `tf-autofix.yml`;
+  the workflow skips it for you. If your prompt sees that label_name
+  anyway, exit-noop.
 - Never double-process. GitHub may redeliver webhooks; be idempotent
-  (e.g. skip adding a label that's already present).
-- If the event is for the `meta-state` issue, exit immediately.
+  (e.g. skip adding a label that's already present, skip closing an
+  already-closed issue).

--- a/.github/workflows/tf-react.yml
+++ b/.github/workflows/tf-react.yml
@@ -1,0 +1,133 @@
+name: tf-react
+
+# Reacts to owner activity on TestFlight-sourced issues:
+#
+#   1. Owner adds a label              → process label intent (defer / dismissed / regression)
+#   2. Owner closes an issue           → treat as dismiss if not yet shipped
+#   3. Owner posts a comment           → parse intent (approve / defer / dismiss / refine)
+#
+# This complements tf-autofix.yml, which handles the auto-fix-approved label add
+# and Xcode Cloud check_run completions for autofix branches.
+#
+# Lives in Actions (not Routines) because Claude Code Routines does not yet
+# expose the issue_comment webhook — only issues / pull_request / release /
+# schedule. Comment-driven intent (the most ergonomic owner path) requires
+# this event, so the whole tf-react logic moved here for consistency.
+
+on:
+  issues:
+    types: [labeled, closed]
+  issue_comment:
+    types: [created]
+
+jobs:
+  resolve:
+    # Filter out events that don't apply, then forward the relevant payload
+    # fields as outputs so the downstream job (and concurrency key) can read
+    # them without re-parsing github.event.
+    runs-on: ubuntu-latest
+    outputs:
+      proceed: ${{ steps.ctx.outputs.proceed }}
+      issue_number: ${{ steps.ctx.outputs.issue_number }}
+      event_action: ${{ steps.ctx.outputs.event_action }}
+      label_name: ${{ steps.ctx.outputs.label_name }}
+      actor: ${{ steps.ctx.outputs.actor }}
+    steps:
+      - name: Resolve event
+        id: ctx
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
+          LABEL_NAME: ${{ github.event.label.name }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          SENDER_LOGIN: ${{ github.event.sender.login }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          ISSUE_LABELS: ${{ toJSON(github.event.issue.labels) }}
+        run: |
+          set -euo pipefail
+
+          emit_skip() {
+            echo "$1"
+            { echo "proceed=false"; } >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+
+          # Owner-only: anyone able to comment on / label public issues could
+          # otherwise trigger billed Claude runs with issues:write.
+          if [ "$SENDER_LOGIN" != "$REPO_OWNER" ]; then
+            emit_skip "Sender '$SENDER_LOGIN' is not owner '$REPO_OWNER'; skipping."
+          fi
+
+          # Only TestFlight-sourced issues. Filter on the issue's label set
+          # rather than the event payload so this works for issue_comment
+          # (where the label that fired isn't part of the payload).
+          if ! echo "$ISSUE_LABELS" | jq -e '.[] | select(.name == "source:testflight-api")' > /dev/null; then
+            emit_skip "Issue does not carry source:testflight-api label; skipping."
+          fi
+
+          # Never react to events on the persistent state-carrier issue.
+          if echo "$ISSUE_LABELS" | jq -e '.[] | select(.name == "meta-state")' > /dev/null; then
+            emit_skip "meta-state issue; skipping."
+          fi
+
+          # tf-autofix.yml already owns auto-fix-approved label adds. Don't
+          # double-fire — tf-react would just exit-noop per its prompt anyway.
+          if [ "$EVENT_NAME" = "issues" ] \
+             && [ "$EVENT_ACTION" = "labeled" ] \
+             && [ "$LABEL_NAME" = "auto-fix-approved" ]; then
+            emit_skip "auto-fix-approved label is handled by tf-autofix.yml; skipping."
+          fi
+
+          {
+            echo "proceed=true"
+            echo "issue_number=$ISSUE_NUMBER"
+            echo "event_action=$EVENT_ACTION"
+            echo "label_name=$LABEL_NAME"
+            echo "actor=$SENDER_LOGIN"
+          } >> "$GITHUB_OUTPUT"
+
+  react:
+    needs: resolve
+    if: needs.resolve.outputs.proceed == 'true'
+    runs-on: ubuntu-latest
+    # Serialize per issue: label-add and a near-simultaneous comment from the
+    # owner shouldn't race each other on the same issue body / labels.
+    concurrency:
+      group: tf-react-issue-${{ needs.resolve.outputs.issue_number }}
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Assemble prompt (_shared.md + tf-react.md)
+        id: prompt
+        run: |
+          set -euo pipefail
+          {
+            echo 'content<<PROMPT_EOF'
+            cat .claude/routines/_shared.md
+            printf '\n\n---\n\n'
+            cat .claude/routines/tf-react.md
+            echo 'PROMPT_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run Claude
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ needs.resolve.outputs.issue_number }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ needs.resolve.outputs.event_action }}
+          LABEL_NAME: ${{ needs.resolve.outputs.label_name }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          ACTOR: ${{ needs.resolve.outputs.actor }}
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_PRIVATE_KEY: ${{ secrets.ASC_PRIVATE_KEY }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: ${{ steps.prompt.outputs.content }}
+          allowed_tools: "Bash,Read,Grep,Glob"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/tf-react.yml` (issues + issue_comment triggers, owner-only, source:testflight-api filter, per-issue concurrency, calls anthropics/claude-code-action with the `_shared.md + tf-react.md` prompt).
- Updates `.claude/routines/README.md` topology table — tf-react now lives in Actions, leaving only tf-triage and tf-ship as Routines.
- Updates `.claude/routines/tf-react.md` to read from explicit env vars set by the workflow rather than implicit webhook context.

## Why

Claude Code Routines does not yet expose the `issue_comment` event. Without it, the comment-driven approve/defer/dismiss/refine flow described in tf-react.md is unreachable — only label changes and closures fire.

Moving tf-react to Actions, mirroring the tf-autofix.yml pattern, restores comment-driven intent and consolidates owner-interaction logic in one place. tf-autofix.yml continues to own the `auto-fix-approved` label-add → autofix path; tf-react.yml skips that label so they don't double-fire.

## Test plan

- [ ] Land this PR; the new workflow appears under Actions tab.
- [ ] Comment "approve A" on an existing TF issue — tf-react.yml should fire, label `auto-fix-approved` gets applied, tf-autofix.yml then takes over.
- [ ] Comment "dismiss" on a TF issue — tf-react.yml closes it.
- [ ] Add `defer` label by hand — tf-react.yml fires, removes needs-review.
- [ ] Comment on the meta-state issue — workflow should skip (verify in Actions log).