### PR TITLE
ci: pin tf-cycle Actions to opus-4-7[1m] xhigh effort

### DIFF
--- a/.github/workflows/tf-autofix.yml
+++ b/.github/workflows/tf-autofix.yml
@@ -137,3 +137,6 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.prompt.outputs.content }}
           allowed_tools: "Bash,Read,Edit,Write,Grep,Glob"
+          claude_args: |
+            --model claude-opus-4-7[1m]
+            --effort xhigh

--- a/.github/workflows/tf-react.yml
+++ b/.github/workflows/tf-react.yml
@@ -131,3 +131,6 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.prompt.outputs.content }}
           allowed_tools: "Bash,Read,Grep,Glob"
+          claude_args: |
+            --model claude-opus-4-7[1m]
+            --effort xhigh

--- a/.github/workflows/tf-ship-finalize.yml
+++ b/.github/workflows/tf-ship-finalize.yml
@@ -93,3 +93,6 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.prompt.outputs.content }}
           allowed_tools: "Bash,Read,Grep,Glob"
+          claude_args: |
+            --model claude-opus-4-7[1m]
+            --effort xhigh


### PR DESCRIPTION
## Summary

- Adds `claude_args: --model claude-opus-4-7[1m] --effort xhigh` to all three tf-cycle workflows (tf-react, tf-autofix, tf-ship-finalize).
- Matches the Routines tier (Opus 4.7 1M-context) and gives autofix the headroom for multi-turn read-code → write-code → verify loops.