### PR TITLE
fix(autofix): merge directly, drop --auto

### DIFF
--- a/.claude/routines/tf-autofix.md
+++ b/.claude/routines/tf-autofix.md
@@ -139,13 +139,31 @@ it's the owner's stamp, not progress state. Re-entry is keyed on
 
 ## Merge mode
 
-1. `gh pr merge <PR> --repo hanbin2007/AIChat --squash --auto`.
-2. On the **PR** (not the issue): add `auto-fix-ready`. This is the
-   label that wakes `tf-ship` on `pull_request closed+merged`.
+We're here because Xcode Cloud already concluded `success` on the
+PR head — the merge is safe right now, no waiting. Don't use
+`--auto`: free-tier private repos can't define required checks via
+branch protection, so `--auto` would stall indefinitely. We already
+know the check is green from the trigger payload, so merge directly.
+
+1. On the **PR** (not the issue): add `auto-fix-ready` **before** the
+   merge. This is the label `tf-ship` filters on at
+   `pull_request closed+merged`; if we add it after the merge, the
+   webhook race could let tf-ship miss the PR.
+   ```bash
+   gh pr edit <PR> --repo hanbin2007/AIChat --add-label auto-fix-ready
+   ```
+2. Merge:
+   ```bash
+   gh pr merge <PR> --repo hanbin2007/AIChat --squash --delete-branch
+   ```
+   The repo has `delete_branch_on_merge=true`, so `--delete-branch`
+   is belt-and-suspenders, but explicit is better.
 3. Comment on issue:
-   `@hanbin2007 Xcode Cloud ✅ → PR #<PR> queued for merge.`
-4. Exit. The `pull_request closed+merged` event will fire
-   `tf-ship` later.
+   `@hanbin2007 Xcode Cloud ✅ → PR #<PR> merged.`
+4. Exit. The merged-PR webhook fires `tf-ship`, which writes
+   `WhatToTest.*.txt` and pushes main; Xcode Cloud's Ship workflow
+   then runs and `tf-ship-finalize.yml` closes this issue when it
+   reports success.
 
 ## Fail mode
 


### PR DESCRIPTION
## Summary

- `gh pr merge --auto --squash` in Merge mode stalls on free-tier private repos (no branch-protection-required-checks → auto-merge has nothing to wait on, never fires).
- By the time tf-autofix routes to Merge mode, the success `check_run` is already in the trigger payload — so we don't need to wait. Switch to `gh pr merge --squash --delete-branch` (immediate merge).
- Apply `auto-fix-ready` label *before* the merge so the `pull_request.closed+merged` webhook handed to `tf-ship` reliably has it.
- Repo settings flipped alongside: `allow_auto_merge=true` (defensive only; --auto is gone) + `delete_branch_on_merge=true` (cleanup).

## Result

End-to-end loop becomes truly hands-off after `auto-fix-approved`:
issue approved → autofix iterates with Xcode Cloud → on green check, merges itself → tf-ship pushes WhatToTest → Xcode Cloud Ship runs → tf-ship-finalize closes the issue.