### PR TITLE
fix: unify version strings across all targets

### DIFF
--- a/AIChat.xcodeproj/project.pbxproj
+++ b/AIChat.xcodeproj/project.pbxproj
@@ -987,7 +987,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Config/AIChatWatchApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = "$(APP_BUILD_VERSION)";
 				DEVELOPMENT_TEAM = NCLY9ZGRMZ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1008,7 +1008,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2;
+				MARKETING_VERSION = "$(APP_MARKETING_VERSION)";
 				PRODUCT_BUNDLE_IDENTIFIER = hanbin.AIChat.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -1032,7 +1032,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Config/AIChatWatchApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = "$(APP_BUILD_VERSION)";
 				DEVELOPMENT_TEAM = NCLY9ZGRMZ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1053,7 +1053,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2;
+				MARKETING_VERSION = "$(APP_MARKETING_VERSION)";
 				PRODUCT_BUNDLE_IDENTIFIER = hanbin.AIChat.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;

--- a/Config/Shared.xcconfig
+++ b/Config/Shared.xcconfig
@@ -1,7 +1,7 @@
 #include? "Secrets.xcconfig"
 
-APP_MARKETING_VERSION = 2.1
-APP_BUILD_VERSION = 4
+APP_MARKETING_VERSION = 2.2
+APP_BUILD_VERSION = 7
 
 AI_BACKEND_MODE = relay
 GEMINI_MODEL = gemini-3-flash-preview


### PR DESCRIPTION
Watch App build configs had hardcoded `CURRENT_PROJECT_VERSION = 1` + `MARKETING_VERSION = 2.2` while iOS/Relay/Keygen/Widget interpolated from xcconfig. Every archive embedded Watch 2.2(1) inside iOS 2.1(N) — TestFlight rejects mixed-version bundles, which is what Build #6 / #7 export-archive was hitting.

- pbxproj: 4 hardcoded lines → xcconfig interpolation, matching the rest
- Shared.xcconfig: bump to 2.2(7) (TF has 2.1(6); 2.2 is next valid marketing version, 7 stays above all extant builds)
- ci_pre_xcodebuild.sh continues to overwrite CFBundleVersion with CI_BUILD_NUMBER in the cloud, so monotonicity is preserved end-to-end