### PR TITLE
ci: move tf-triage and tf-ship to GitHub Actions

### DIFF
--- a/.claude/routines/_shared.md
+++ b/.claude/routines/_shared.md
@@ -87,23 +87,20 @@ python3 .claude/routines/scripts/asc.py build-log --run "$RUN_ID"
 python3 .claude/routines/scripts/asc.py get "/v1/ciBuildRuns/$RUN_ID"
 ```
 
-Required env vars on every routine that calls ASC (mark secrets in the
-Routines UI):
-- `ASC_KEY_ID` — 10-char key id (secret)
-- `ASC_ISSUER_ID` — issuer UUID (secret)
-- `ASC_PRIVATE_KEY` — full PEM contents of the `.p8` (secret), including
+Required env vars / secrets on every job that calls ASC:
+- `ASC_KEY_ID` — 10-char key id
+- `ASC_ISSUER_ID` — issuer UUID
+- `ASC_PRIVATE_KEY` — full PEM contents of the `.p8`, including
   `-----BEGIN PRIVATE KEY-----` / `-----END PRIVATE KEY-----`
-- `ASC_PRODUCT_ID` — only on routines that talk to Xcode Cloud (secret)
-- `ASC_BASE_URL` — **required from Routines.** Anthropic's sandbox
-  returns 503 for `api.appstoreconnect.apple.com` even at "Full"
-  network tier (apple.com is not on the egress allowlist; possibly
-  also Apple-side IP filtering). Set this to the relay's bridge —
-  `https://ai.origenclub.cn/api/asc` — and `asc.py` rewrites every API
-  call through there. The JWT is end-to-end; the relay just forwards
-  bytes. Leave unset for local invocations from a Mac.
+- `ASC_PRODUCT_ID` — only on jobs that talk to Xcode Cloud
 
 `ASC_APP_ID` is hardcoded in `asc.py` (`DEFAULT_APP_ID`); override with
 the env var only if you fork this for a different app.
+
+`ASC_BASE_URL` exists as an escape hatch for sandboxes that can't reach
+`api.appstoreconnect.apple.com` directly — it points `asc.py` at the
+relay's `/api/asc` proxy. GitHub-hosted runners reach Apple directly,
+so leave it unset there.
 
 ## Per-fix state (no state file needed)
 

--- a/.github/workflows/tf-ship.yml
+++ b/.github/workflows/tf-ship.yml
@@ -1,0 +1,74 @@
+name: tf-ship
+
+# When an auto-fix PR merges into main, write the TestFlight WhatToTest
+# changelog files and push main so Xcode Cloud's Ship to TestFlight
+# workflow picks it up. Replaces the Anthropic Routines trigger of the
+# same name.
+#
+# Pairs with tf-ship-finalize.yml, which closes the linked issues and
+# strips labels once Xcode Cloud reports the upload result on the main
+# commit's check_run.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+# Filter to merged PRs from autofix/* branches that carry auto-fix-ready.
+# tf-react / tf-autofix sets that label only after Xcode Cloud passes.
+jobs:
+  ship:
+    if: |
+      github.event.pull_request.merged == true
+      && startsWith(github.event.pull_request.head.ref, 'autofix/')
+      && contains(github.event.pull_request.labels.*.name, 'auto-fix-ready')
+    runs-on: ubuntu-latest
+    # Serialize ships: each push of main kicks Xcode Cloud's Ship workflow,
+    # and two simultaneous changelog writes would race the rebase.
+    concurrency:
+      group: tf-ship
+      cancel-in-progress: false
+    permissions:
+      contents: write
+      issues: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # Need a token that can push to main — GITHUB_TOKEN works because
+          # the repo's Actions write permission is enabled and there's no
+          # branch protection blocking it.
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git author
+        run: |
+          git config user.name  "tf-ship-bot"
+          git config user.email "tf-ship-bot@users.noreply.github.com"
+
+      - name: Assemble prompt (_shared.md + tf-ship.md)
+        id: prompt
+        run: |
+          set -euo pipefail
+          {
+            echo 'content<<PROMPT_EOF'
+            cat .claude/routines/_shared.md
+            printf '\n\n---\n\n'
+            cat .claude/routines/tf-ship.md
+            echo 'PROMPT_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run Claude
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MERGED_PR_NUMBER: ${{ github.event.pull_request.number }}
+          MERGED_PR_HEAD: ${{ github.event.pull_request.head.ref }}
+          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: ${{ steps.prompt.outputs.content }}
+          allowed_tools: "Bash,Read,Grep,Glob"
+          claude_args: |
+            --model claude-opus-4-7[1m]
+            --effort xhigh

--- a/.github/workflows/tf-triage.yml
+++ b/.github/workflows/tf-triage.yml
@@ -1,0 +1,57 @@
+name: tf-triage
+
+# Hourly pull of new TestFlight feedback from App Store Connect, files each
+# new item as a GitHub issue with classification + investigation. Replaces
+# the Anthropic Routines schedule of the same name; lives here so:
+#
+#   - apple.com is directly reachable from GitHub-hosted runners (no relay
+#     proxy needed)
+#   - ASC secrets and the autofix loop live in one place
+#   - manual replay (workflow_dispatch) is one click
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+# Hourly cron and a manual replay must not stomp on each other's
+# meta-state cursor write.
+concurrency:
+  group: tf-triage
+  cancel-in-progress: false
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Assemble prompt (_shared.md + tf-triage.md)
+        id: prompt
+        run: |
+          set -euo pipefail
+          {
+            echo 'content<<PROMPT_EOF'
+            cat .claude/routines/_shared.md
+            printf '\n\n---\n\n'
+            cat .claude/routines/tf-triage.md
+            echo 'PROMPT_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run Claude
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_PRIVATE_KEY: ${{ secrets.ASC_PRIVATE_KEY }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: ${{ steps.prompt.outputs.content }}
+          allowed_tools: "Bash,Read,Grep,Glob,Task"
+          claude_args: |
+            --model claude-opus-4-7[1m]
+            --effort xhigh


### PR DESCRIPTION
## Summary
Migrates the last two Anthropic Routines (tf-triage hourly, tf-ship on PR-closed) to GitHub Actions so the whole tf-cycle runs on a single platform.

- \`.github/workflows/tf-triage.yml\` — schedule \`0 * * * *\` + \`workflow_dispatch\`
- \`.github/workflows/tf-ship.yml\` — \`pull_request: closed\` filtered to merged \`autofix/*\` PRs carrying \`auto-fix-ready\`
- \`_shared.md\` — drop the Routines-specific \`ASC_BASE_URL\` directive; keep it as an escape hatch only

Why now: Routines doesn't expose \`issue_comment\`, has a 1-hour cron floor, and its sandbox blocks \`apple.com\` (we built a relay proxy just to work around that). GHA solves all three.

## Test plan
- [ ] Manual replay: trigger tf-triage via Actions → workflow_dispatch and verify the same \`triage OK\` summary as the most recent Routines run.
- [ ] Wait for the first scheduled cron firing.
- [ ] On the next autofix merge, verify tf-ship runs and pushes main with the WhatToTest changelog.
- [ ] Once both have fired green at least once, delete the two Routines from the Claude Code web UI.