### PR TITLE
ci: pass github_token to claude-code-action

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,6 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |

--- a/.github/workflows/tf-autofix.yml
+++ b/.github/workflows/tf-autofix.yml
@@ -135,6 +135,7 @@ jobs:
           ASC_PRODUCT_ID: ${{ secrets.ASC_PRODUCT_ID }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: ${{ steps.prompt.outputs.content }}
           allowed_tools: "Bash,Read,Edit,Write,Grep,Glob"
           claude_args: |

--- a/.github/workflows/tf-react.yml
+++ b/.github/workflows/tf-react.yml
@@ -129,6 +129,7 @@ jobs:
           ASC_PRIVATE_KEY: ${{ secrets.ASC_PRIVATE_KEY }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: ${{ steps.prompt.outputs.content }}
           allowed_tools: "Bash,Read,Grep,Glob"
           claude_args: |

--- a/.github/workflows/tf-ship-finalize.yml
+++ b/.github/workflows/tf-ship-finalize.yml
@@ -91,6 +91,7 @@ jobs:
           ASC_PRODUCT_ID: ${{ secrets.ASC_PRODUCT_ID }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: ${{ steps.prompt.outputs.content }}
           allowed_tools: "Bash,Read,Grep,Glob"
           claude_args: |

--- a/.github/workflows/tf-ship.yml
+++ b/.github/workflows/tf-ship.yml
@@ -67,6 +67,7 @@ jobs:
           MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: ${{ steps.prompt.outputs.content }}
           allowed_tools: "Bash,Read,Grep,Glob"
           claude_args: |

--- a/.github/workflows/tf-triage.yml
+++ b/.github/workflows/tf-triage.yml
@@ -50,6 +50,7 @@ jobs:
           ASC_PRIVATE_KEY: ${{ secrets.ASC_PRIVATE_KEY }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: ${{ steps.prompt.outputs.content }}
           allowed_tools: "Bash,Read,Grep,Glob,Task"
           claude_args: |


### PR DESCRIPTION
Unblocks tf-react/tf-triage which were failing with the OIDC `id-token: write` error since the action started requiring either OIDC perms or an explicit github_token input. Applied uniformly to every workflow that uses claude-code-action@v1.