### PR TITLE
ci: move allowed_tools into claude_args

### DIFF
--- a/.github/workflows/tf-autofix.yml
+++ b/.github/workflows/tf-autofix.yml
@@ -137,7 +137,8 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: ${{ steps.prompt.outputs.content }}
-          allowed_tools: "Bash,Read,Edit,Write,Grep,Glob"
           claude_args: |
             --model claude-opus-4-7[1m]
             --effort xhigh
+            --max-turns 80
+            --allowedTools Bash,Read,Edit,Write,Grep,Glob,Task

--- a/.github/workflows/tf-react.yml
+++ b/.github/workflows/tf-react.yml
@@ -131,7 +131,8 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: ${{ steps.prompt.outputs.content }}
-          allowed_tools: "Bash,Read,Grep,Glob"
           claude_args: |
             --model claude-opus-4-7[1m]
             --effort xhigh
+            --max-turns 30
+            --allowedTools Bash,Read,Grep,Glob

--- a/.github/workflows/tf-ship-finalize.yml
+++ b/.github/workflows/tf-ship-finalize.yml
@@ -93,7 +93,8 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: ${{ steps.prompt.outputs.content }}
-          allowed_tools: "Bash,Read,Grep,Glob"
           claude_args: |
             --model claude-opus-4-7[1m]
+            --max-turns 30
+            --allowedTools Bash,Read,Grep,Glob
             --effort xhigh

--- a/.github/workflows/tf-ship.yml
+++ b/.github/workflows/tf-ship.yml
@@ -69,7 +69,8 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: ${{ steps.prompt.outputs.content }}
-          allowed_tools: "Bash,Read,Grep,Glob"
           claude_args: |
             --model claude-opus-4-7[1m]
             --effort xhigh
+            --max-turns 30
+            --allowedTools Bash,Read,Grep,Glob

--- a/.github/workflows/tf-triage.yml
+++ b/.github/workflows/tf-triage.yml
@@ -52,7 +52,8 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: ${{ steps.prompt.outputs.content }}
-          allowed_tools: "Bash,Read,Grep,Glob,Task"
           claude_args: |
             --model claude-opus-4-7[1m]
             --effort xhigh
+            --max-turns 80
+            --allowedTools Bash,Read,Grep,Glob,Task


### PR DESCRIPTION
Bug: `allowed_tools:` is not a valid input of claude-code-action@v1 (only `prompt`, `settings`, `claude_args` are). It was being silently dropped, leaving the CLI tool-less. The first GHA tf-triage run exited 1-turn 3.2s without doing any work.

Fix: move into `claude_args` as `--allowedTools <list>`, and add `--max-turns` explicitly.