### PR TITLE
ci: fix all tf-cycle workflows on GHA (imperative directive + diagnostics)

### DIFF
--- a/.github/workflows/tf-autofix.yml
+++ b/.github/workflows/tf-autofix.yml
@@ -113,8 +113,15 @@ jobs:
         id: prompt
         run: |
           set -euo pipefail
+          # The action's default `claude_code` system-prompt preset reads
+          # markdown specs as docs/role-assignment unless an imperative
+          # directive opens the user message. See debug/tf-triage-diagnostics.
           {
             echo 'content<<PROMPT_EOF'
+            echo 'Execute the AUTOFIX routine described below right now on the issue specified by the env vars (ISSUE_NUMBER, CHECK_CONCLUSION, CHECK_DETAILS_URL, CHECK_NAME). Use the available tools (Bash, Read, Edit, Write, Grep, Glob, Task) as needed. Do not ask for confirmation. End with the summary line specified in the routine.'
+            echo
+            echo '---'
+            echo
             cat .claude/routines/_shared.md
             printf '\n\n---\n\n'
             cat .claude/routines/tf-autofix.md
@@ -139,6 +146,5 @@ jobs:
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: |
             --model claude-opus-4-7[1m]
-            --effort xhigh
             --max-turns 80
             --allowedTools Bash,Read,Edit,Write,Grep,Glob,Task

--- a/.github/workflows/tf-react.yml
+++ b/.github/workflows/tf-react.yml
@@ -106,8 +106,15 @@ jobs:
         id: prompt
         run: |
           set -euo pipefail
+          # The action's default `claude_code` system-prompt preset reads
+          # markdown specs as docs/role-assignment unless an imperative
+          # directive opens the user message. See debug/tf-triage-diagnostics.
           {
             echo 'content<<PROMPT_EOF'
+            echo 'Execute the REACT routine described below right now on the issue specified by the env vars (EVENT_NAME, EVENT_ACTION, ISSUE_NUMBER, LABEL_NAME, COMMENT_BODY, ACTOR). Use the available tools (Bash, Read, Grep, Glob) as needed. Do not ask for confirmation. End with the summary line specified in the routine.'
+            echo
+            echo '---'
+            echo
             cat .claude/routines/_shared.md
             printf '\n\n---\n\n'
             cat .claude/routines/tf-react.md
@@ -133,6 +140,5 @@ jobs:
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: |
             --model claude-opus-4-7[1m]
-            --effort xhigh
             --max-turns 30
             --allowedTools Bash,Read,Grep,Glob

--- a/.github/workflows/tf-ship-finalize.yml
+++ b/.github/workflows/tf-ship-finalize.yml
@@ -70,8 +70,15 @@ jobs:
         id: prompt
         run: |
           set -euo pipefail
+          # The action's default `claude_code` system-prompt preset reads
+          # markdown specs as docs/role-assignment unless an imperative
+          # directive opens the user message. See debug/tf-triage-diagnostics.
           {
             echo 'content<<PROMPT_EOF'
+            echo 'Execute the SHIP-FINALIZE routine described below right now on the check_run that fired this workflow (env vars CHECK_CONCLUSION, CHECK_DETAILS_URL, CHECK_NAME, COMMIT_SHA). Use the available tools (Bash, Read, Grep, Glob) as needed. Do not ask for confirmation. End with the summary line specified in the routine.'
+            echo
+            echo '---'
+            echo
             cat .claude/routines/_shared.md
             printf '\n\n---\n\n'
             cat .claude/routines/tf-ship-finalize.md
@@ -97,4 +104,3 @@ jobs:
             --model claude-opus-4-7[1m]
             --max-turns 30
             --allowedTools Bash,Read,Grep,Glob
-            --effort xhigh

--- a/.github/workflows/tf-ship.yml
+++ b/.github/workflows/tf-ship.yml
@@ -50,8 +50,15 @@ jobs:
         id: prompt
         run: |
           set -euo pipefail
+          # The action's default `claude_code` system-prompt preset reads
+          # markdown specs as docs/role-assignment unless an imperative
+          # directive opens the user message. See debug/tf-triage-diagnostics.
           {
             echo 'content<<PROMPT_EOF'
+            echo 'Execute the SHIP routine described below right now. Use the available tools (Bash, Read, Grep, Glob) as needed. Do not ask for confirmation. End with the summary line specified in the "Summary line" section.'
+            echo
+            echo '---'
+            echo
             cat .claude/routines/_shared.md
             printf '\n\n---\n\n'
             cat .claude/routines/tf-ship.md
@@ -71,6 +78,5 @@ jobs:
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: |
             --model claude-opus-4-7[1m]
-            --effort xhigh
             --max-turns 30
             --allowedTools Bash,Read,Grep,Glob

--- a/.github/workflows/tf-triage.yml
+++ b/.github/workflows/tf-triage.yml
@@ -33,8 +33,17 @@ jobs:
         id: prompt
         run: |
           set -euo pipefail
+          # The action sends the prompt input to Claude Code under the
+          # default `claude_code` system-prompt preset, which treats long
+          # markdown as docs/role-assignment rather than a command. Without
+          # an explicit imperative leader, Claude responds "Ready. What
+          # would you like me to do?" and exits. Prepend a one-line directive.
           {
             echo 'content<<PROMPT_EOF'
+            echo 'Execute the TRIAGE routine described below right now. Use the available tools (Bash, Read, Grep, Glob, Task) as needed. Do not ask for confirmation. End with the summary line specified in the "Summary line" section.'
+            echo
+            echo '---'
+            echo
             cat .claude/routines/_shared.md
             printf '\n\n---\n\n'
             cat .claude/routines/tf-triage.md

--- a/.github/workflows/tf-triage.yml
+++ b/.github/workflows/tf-triage.yml
@@ -51,9 +51,17 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          show_full_output: "true"
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: |
             --model claude-opus-4-7[1m]
-            --effort xhigh
             --max-turns 80
             --allowedTools Bash,Read,Grep,Glob,Task
+
+      - name: Upload Claude session log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-execution-output
+          path: /home/runner/work/_temp/claude-execution-output.json
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary
First scheduled GHA run of tf-triage exited at 1 turn / 5.7s with no tool calls. Diagnostic artifact (\`claude-execution-output.json\`) showed Claude responding with **\"Ready. What would you like me to do?\"**.

Root cause: \`anthropics/claude-code-action@v1\` sends our \`prompt:\` content as the user message under the default \`claude_code\` system-prompt preset (see \`base-action/src/parse-sdk-options.ts\` l239-258). Under that preset, a long markdown body that opens with *\"You are the TRIAGE routine...\"* reads like role assignment, not a command. Routines wraps prompts implicitly; the action does not.

## Changes
- **Diagnostics on tf-triage** — \`show_full_output: true\` + uploads \`claude-execution-output.json\` as an artifact. Cheap and saves an hour next time anything misbehaves.
- **One-line imperative leader** prepended to every tf workflow's assembled prompt: \`\"Execute the X routine described below right now. ...\"\`
- **Dropped \`--effort xhigh\`** — not a documented Claude CLI flag (inherited from PR #13).

## Verified
- tf-triage on \`debug/tf-triage-diagnostics\` (run 24957718281): **49 turns, 4 new issues filed (#29-#32), \`triage OK — processed: 4, new: 4, duped: 0, reopened: 0\`**, cursor advanced to 2026-04-26T10:36:22.467Z.

## Test plan
- [x] tf-triage runs end-to-end on workflow_dispatch.
- [ ] Wait for first scheduled cron firing on main.
- [ ] On the next autofix merge, verify tf-ship runs and pushes main with the WhatToTest changelog.
- [ ] Once both are green at least once, delete the two Routines from the Claude Code web UI.