### PR TITLE
fix(ci): handle test-without-building runner + Apple's action_required

### DIFF
--- a/.claude/routines/tf-autofix.md
+++ b/.claude/routines/tf-autofix.md
@@ -58,9 +58,13 @@ lowercased value to handle both.
 | no | — | — | **Start** |
 | yes | `in_progress` / `queued` | any | exit noop (still building) |
 | yes | `success` | any | **Merge** |
-| yes | `failure` / `cancelled` / `timed_out` | < 3 | **Iterate** |
-| yes | `failure` / `cancelled` / `timed_out` | ≥ 3 | **Fail** |
+| yes | `failure` / `cancelled` / `timed_out` / `action_required` | < 3 | **Iterate** |
+| yes | `failure` / `cancelled` / `timed_out` / `action_required` | ≥ 3 | **Fail** |
 | yes | no check yet | any | exit noop (give Xcode Cloud 5 min) |
+
+> Apple's Xcode Cloud reports test failures with conclusion
+> `action_required` (it expects a human to acknowledge/retry) rather
+> than `failure`. Treat both as terminal-fail for the iteration count.
 
 Fetch state:
 ```bash

--- a/.github/workflows/tf-autofix.yml
+++ b/.github/workflows/tf-autofix.yml
@@ -40,7 +40,12 @@ jobs:
           ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
           SENDER_LOGIN: ${{ github.event.sender.login }}
           REPO_OWNER: ${{ github.repository_owner }}
-          BRANCH: ${{ github.event.check_run.check_suite.head_branch }}
+          # check_suite.head_branch is unreliable when a SHA is reachable
+          # from multiple refs — observed on 2026-04-26 reporting an old
+          # diagnostic branch name for an autofix/issue-* SHA. Prefer the
+          # PR's head.ref via the check_run.pull_requests array; fall back
+          # to head_branch only when no PR is associated.
+          BRANCH: ${{ github.event.check_run.pull_requests[0].head.ref || github.event.check_run.check_suite.head_branch }}
           CHECK_CONCLUSION: ${{ github.event.check_run.conclusion }}
           CHECK_DETAILS_URL: ${{ github.event.check_run.details_url }}
           CHECK_NAME: ${{ github.event.check_run.name }}
@@ -63,8 +68,11 @@ jobs:
             fi
           elif [ "$EVENT_NAME" = "check_run" ] \
                && [[ "$BRANCH" =~ ^autofix/issue-([0-9]+)$ ]]; then
+            # Apple's Xcode Cloud reports test failures as `action_required`
+            # (it wants a human to look) rather than `failure`. We treat it
+            # as terminal here so the autofix routine can iterate.
             case "$CHECK_CONCLUSION" in
-              success|failure|cancelled|timed_out)
+              success|failure|cancelled|timed_out|action_required)
                 proceed=true
                 issue_number="${BASH_REMATCH[1]}"
                 {

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -4,6 +4,15 @@ set -eu
 # Xcode Cloud runs this immediately after the repo is cloned, before any
 # Xcode resolution. Working directory: $CI_PRIMARY_REPOSITORY_PATH/ci_scripts.
 # We rewrite to repo root so paths match local dev.
+
+# test-without-building runs on a fresh runner that never had a clone;
+# the post-clone hook still fires there, but with no repo to act on.
+# Skip cleanly so `set -eu` doesn't kill the pipeline.
+if [ -z "${CI_PRIMARY_REPOSITORY_PATH:-}" ]; then
+  echo "ci_post_clone: no repo on this runner (test-without-building); nothing to do"
+  exit 0
+fi
+
 cd "$CI_PRIMARY_REPOSITORY_PATH"
 
 # Config/Secrets.xcconfig is gitignored locally. In the cloud we synthesize

--- a/ci_scripts/ci_pre_xcodebuild.sh
+++ b/ci_scripts/ci_pre_xcodebuild.sh
@@ -9,6 +9,16 @@ set -eu
 # Only meaningful for archive workflows. PR/test workflows can run this
 # too — agvtool just no-ops if the value is unchanged.
 
+# Apple's test-without-building action runs on a fresh runner that never
+# had a clone, so CI_PRIMARY_REPOSITORY_PATH is unset there. Without this
+# guard `set -eu` aborts the whole pipeline (the .xctestproducts already
+# carries the version baked in during build-for-testing — nothing to do
+# on the test runner).
+if [ -z "${CI_PRIMARY_REPOSITORY_PATH:-}" ]; then
+  echo "ci_pre_xcodebuild: no repo on this runner (test-without-building); nothing to do"
+  exit 0
+fi
+
 cd "$CI_PRIMARY_REPOSITORY_PATH"
 
 if [ -z "${CI_BUILD_NUMBER:-}" ]; then


### PR DESCRIPTION
## Summary
Three related defects surfaced while reviewing PR #33's failed Xcode Cloud test:

1. **\`Test - iOS\` / \`Test - watchOS\` fail with \`CI_PRIMARY_REPOSITORY_PATH: unbound variable\`.**
   Apple's \`test-without-building\` action runs on a fresh runner with no clone but still invokes the post-clone / pre-xcodebuild hooks. \`set -eu\` aborts on the unset var. Both scripts now no-op cleanly when the var isn't set.

2. **tf-autofix never iterated.** Apple reports test failures with \`conclusion: action_required\` (not \`failure\`). Our resolve gate dropped it. Add it to the terminal-fail set so Iterate / Fail modes engage. Decision table updated.

3. **BRANCH was wrong.** \`check_suite.head_branch\` reported \`debug/tf-triage-diagnostics\` for an \`autofix/issue-*\` SHA, so the regex missed and the workflow skipped. Switch to \`check_run.pull_requests[0].head.ref\` (with the old field as fallback).

## Verified
- Xcode Cloud Build phase succeeded for PR #33 — only Test phase failed with the unbound-var trace; the change above no-ops on the test runner exactly where the error happened.
- Diagnosis confirmed against Apple's check_runs API: 4 check_runs on commit \`9e08598\`, two with conclusion \`action_required\`.

## Test plan
- [ ] Push lands on PR #33's autofix/issue-30 branch (after rebase) — Test - iOS / Test - watchOS pass.
- [ ] Retest tf-autofix's iteration loop on a fresh autofix branch with a fail; verify it now picks up \`action_required\` and pushes a follow-up commit.