### PR TITLE
ci: bridge check_run → workflow_dispatch for tf-autofix and tf-ship-finalize

### DIFF
--- a/.github/workflows/tf-autofix-bridge.yml
+++ b/.github/workflows/tf-autofix-bridge.yml
@@ -1,0 +1,61 @@
+name: tf-autofix-bridge
+
+# Converts Xcode Cloud's check_run.completed events into a workflow_dispatch
+# call on tf-autofix.yml. Necessary because anthropics/claude-code-action@v1
+# rejects check_run as an "Unsupported event type", so we can't invoke
+# Claude directly from a check_run-triggered workflow.
+#
+# Pure routing — no Claude invocation here. Owner-permission and label
+# enforcement are unchanged from when this lived in tf-autofix.yml.
+
+on:
+  check_run:
+    types: [completed]
+
+permissions:
+  actions: write   # gh workflow run dispatch
+  contents: read
+
+jobs:
+  bridge:
+    runs-on: ubuntu-latest
+    env:
+      # check_suite.head_branch is unreliable when a SHA is reachable from
+      # multiple refs; prefer the PR's head.ref via the check_run.pull_requests
+      # array. See PR #34 / 2026-04-26 incident.
+      BRANCH: ${{ github.event.check_run.pull_requests[0].head.ref || github.event.check_run.check_suite.head_branch }}
+      CHECK_CONCLUSION: ${{ github.event.check_run.conclusion }}
+      CHECK_DETAILS_URL: ${{ github.event.check_run.details_url }}
+      CHECK_NAME: ${{ github.event.check_run.name }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Resolve and dispatch
+        run: |
+          set -euo pipefail
+
+          # Only autofix/issue-<N> branches are interesting here.
+          if ! [[ "$BRANCH" =~ ^autofix/issue-([0-9]+)$ ]]; then
+            echo "BRANCH '$BRANCH' is not an autofix branch; skipping."
+            exit 0
+          fi
+          ISSUE_NUMBER="${BASH_REMATCH[1]}"
+
+          # Apple's Xcode Cloud reports test failures as `action_required`
+          # (not `failure`) — accept it as terminal so the autofix routine
+          # can iterate.
+          case "$CHECK_CONCLUSION" in
+            success|failure|cancelled|timed_out|action_required)
+              ;;
+            *)
+              echo "check_run conclusion '$CHECK_CONCLUSION' not terminal; skipping."
+              exit 0
+              ;;
+          esac
+
+          gh workflow run tf-autofix.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref main \
+            -f issue_number="$ISSUE_NUMBER" \
+            -f check_conclusion="$CHECK_CONCLUSION" \
+            -f check_details_url="$CHECK_DETAILS_URL" \
+            -f check_name="$CHECK_NAME"

--- a/.github/workflows/tf-autofix.yml
+++ b/.github/workflows/tf-autofix.yml
@@ -5,6 +5,11 @@ name: tf-autofix
 #   1. Owner labels an issue `auto-fix-approved`         → Start
 #   2. Xcode Cloud finishes a check on `autofix/issue-*` → Iterate / Merge / Fail
 #
+# Path #2 is delivered as a `check_run.completed` webhook, but
+# anthropics/claude-code-action@v1 rejects check_run as an unsupported
+# event type. tf-autofix-bridge.yml catches check_run and re-dispatches
+# this workflow via workflow_dispatch with the relevant context as inputs.
+#
 # State across runs is read from GitHub itself (branch + PR check status),
 # so this workflow is stateless. The full decision table lives in
 # .claude/routines/tf-autofix.md (Determine mode).
@@ -12,16 +17,23 @@ name: tf-autofix
 on:
   issues:
     types: [labeled]
-  check_run:
-    types: [completed]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number (autofix/issue-<N>)"
+        required: true
+      check_conclusion:
+        description: "Xcode Cloud check_run conclusion (success/failure/action_required/...)"
+        required: false
+      check_details_url:
+        description: "Xcode Cloud build details URL (for log fetching)"
+        required: false
+      check_name:
+        description: "Xcode Cloud check name"
+        required: false
 
 jobs:
   resolve:
-    # First, decide whether this event applies + extract the issue number
-    # from whichever event payload fired. The downstream concurrency group
-    # then keys on issue number (not branch / event type), so an
-    # issues.labeled and a check_run.completed for the same issue queue
-    # against each other rather than racing.
     runs-on: ubuntu-latest
     outputs:
       proceed: ${{ steps.ctx.outputs.proceed }}
@@ -36,19 +48,13 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           EVENT_ACTION: ${{ github.event.action }}
           LABEL_NAME: ${{ github.event.label.name }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+          ISSUE_NUMBER_FROM_EVENT: ${{ github.event.issue.number }}
           SENDER_LOGIN: ${{ github.event.sender.login }}
           REPO_OWNER: ${{ github.repository_owner }}
-          # check_suite.head_branch is unreliable when a SHA is reachable
-          # from multiple refs — observed on 2026-04-26 reporting an old
-          # diagnostic branch name for an autofix/issue-* SHA. Prefer the
-          # PR's head.ref via the check_run.pull_requests array; fall back
-          # to head_branch only when no PR is associated.
-          BRANCH: ${{ github.event.check_run.pull_requests[0].head.ref || github.event.check_run.check_suite.head_branch }}
-          CHECK_CONCLUSION: ${{ github.event.check_run.conclusion }}
-          CHECK_DETAILS_URL: ${{ github.event.check_run.details_url }}
-          CHECK_NAME: ${{ github.event.check_run.name }}
+          DISPATCH_ISSUE_NUMBER: ${{ inputs.issue_number }}
+          DISPATCH_CHECK_CONCLUSION: ${{ inputs.check_conclusion }}
+          DISPATCH_CHECK_DETAILS_URL: ${{ inputs.check_details_url }}
+          DISPATCH_CHECK_NAME: ${{ inputs.check_name }}
         run: |
           set -euo pipefail
           proceed=false
@@ -64,27 +70,18 @@ jobs:
               echo "Label added by '$SENDER_LOGIN' (not owner '$REPO_OWNER'); skipping."
             else
               proceed=true
-              issue_number="$ISSUE_NUMBER"
+              issue_number="$ISSUE_NUMBER_FROM_EVENT"
             fi
-          elif [ "$EVENT_NAME" = "check_run" ] \
-               && [[ "$BRANCH" =~ ^autofix/issue-([0-9]+)$ ]]; then
-            # Apple's Xcode Cloud reports test failures as `action_required`
-            # (it wants a human to look) rather than `failure`. We treat it
-            # as terminal here so the autofix routine can iterate.
-            case "$CHECK_CONCLUSION" in
-              success|failure|cancelled|timed_out|action_required)
-                proceed=true
-                issue_number="${BASH_REMATCH[1]}"
-                {
-                  echo "check_conclusion=$CHECK_CONCLUSION"
-                  echo "check_details_url=$CHECK_DETAILS_URL"
-                  echo "check_name=$CHECK_NAME"
-                } >> "$GITHUB_OUTPUT"
-                ;;
-              *)
-                echo "check_run conclusion '$CHECK_CONCLUSION' not terminal; skipping."
-                ;;
-            esac
+          elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            # tf-autofix-bridge.yml has already validated the autofix
+            # branch + terminal conclusion. Trust the inputs.
+            proceed=true
+            issue_number="$DISPATCH_ISSUE_NUMBER"
+            {
+              echo "check_conclusion=$DISPATCH_CHECK_CONCLUSION"
+              echo "check_details_url=$DISPATCH_CHECK_DETAILS_URL"
+              echo "check_name=$DISPATCH_CHECK_NAME"
+            } >> "$GITHUB_OUTPUT"
           fi
 
           {
@@ -97,7 +94,8 @@ jobs:
     if: needs.resolve.outputs.proceed == 'true'
     runs-on: ubuntu-latest
     # One in-flight run per issue regardless of event source. Issues.labeled
-    # and check_run.completed for the same issue queue rather than race.
+    # and bridge-dispatched check_run events for the same issue queue
+    # rather than race.
     concurrency:
       group: tf-autofix-issue-${{ needs.resolve.outputs.issue_number }}
       cancel-in-progress: false

--- a/.github/workflows/tf-ship-finalize-bridge.yml
+++ b/.github/workflows/tf-ship-finalize-bridge.yml
@@ -1,0 +1,49 @@
+name: tf-ship-finalize-bridge
+
+# Converts Xcode Cloud's `Ship to TestFlight` check_run.completed event on
+# main into a workflow_dispatch call on tf-ship-finalize.yml. Necessary
+# because anthropics/claude-code-action@v1 rejects check_run as an
+# "Unsupported event type", so we can't invoke Claude directly from a
+# check_run-triggered workflow.
+
+on:
+  check_run:
+    types: [completed]
+
+permissions:
+  actions: write   # gh workflow run dispatch
+  contents: read
+
+jobs:
+  bridge:
+    runs-on: ubuntu-latest
+    env:
+      BRANCH: ${{ github.event.check_run.check_suite.head_branch }}
+      CHECK_NAME: ${{ github.event.check_run.name }}
+      CHECK_CONCLUSION: ${{ github.event.check_run.conclusion }}
+      CHECK_DETAILS_URL: ${{ github.event.check_run.details_url }}
+      HEAD_SHA: ${{ github.event.check_run.head_sha }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Resolve and dispatch
+        run: |
+          set -euo pipefail
+
+          # Filter to ship-relevant checks before paying for the dispatch.
+          # Xcode Cloud reports its checks as "Xcode Cloud / <Workflow Name>".
+          if [ "$BRANCH" != "main" ]; then
+            echo "BRANCH '$BRANCH' is not main; skipping."
+            exit 0
+          fi
+          if ! [[ "$CHECK_NAME" =~ ^Xcode\ Cloud[[:space:]]*/[[:space:]]*Ship\ to\ TestFlight$ ]]; then
+            echo "CHECK_NAME '$CHECK_NAME' is not the ship workflow; skipping."
+            exit 0
+          fi
+
+          gh workflow run tf-ship-finalize.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref main \
+            -f main_sha="$HEAD_SHA" \
+            -f check_conclusion="$CHECK_CONCLUSION" \
+            -f check_details_url="$CHECK_DETAILS_URL" \
+            -f check_name="$CHECK_NAME"

--- a/.github/workflows/tf-ship-finalize.yml
+++ b/.github/workflows/tf-ship-finalize.yml
@@ -4,56 +4,31 @@ name: tf-ship-finalize
 # `main` commit. Closes the issues that ship commit references and clears
 # the `auto-fix-ready` label off the PRs.
 #
-# Replaces the in-routine polling loop the old tf-ship had (Routines
-# don't see check_run events; GitHub Actions does, with sub-minute
-# latency).
+# tf-ship-finalize-bridge.yml catches the check_run.completed webhook and
+# re-dispatches this workflow with workflow_dispatch inputs (because
+# anthropics/claude-code-action@v1 doesn't accept check_run events).
 
 on:
-  check_run:
-    types: [completed]
+  workflow_dispatch:
+    inputs:
+      main_sha:
+        description: "Ship commit SHA on main"
+        required: true
+      check_conclusion:
+        description: "Xcode Cloud Ship check conclusion"
+        required: false
+      check_details_url:
+        description: "Xcode Cloud build details URL"
+        required: false
+      check_name:
+        description: "Xcode Cloud check name (e.g. Xcode Cloud / Ship to TestFlight)"
+        required: false
 
 jobs:
-  resolve:
-    # Filter to ship-relevant checks early, before paying for prompt
-    # assembly + Claude. Both the head_branch == main and the check
-    # name guard need to hold.
-    runs-on: ubuntu-latest
-    outputs:
-      proceed: ${{ steps.ctx.outputs.proceed }}
-      main_sha: ${{ steps.ctx.outputs.main_sha }}
-      check_conclusion: ${{ steps.ctx.outputs.check_conclusion }}
-      check_details_url: ${{ steps.ctx.outputs.check_details_url }}
-    steps:
-      - name: Resolve event
-        id: ctx
-        env:
-          BRANCH: ${{ github.event.check_run.check_suite.head_branch }}
-          CHECK_NAME: ${{ github.event.check_run.name }}
-          CHECK_CONCLUSION: ${{ github.event.check_run.conclusion }}
-          CHECK_DETAILS_URL: ${{ github.event.check_run.details_url }}
-          HEAD_SHA: ${{ github.event.check_run.head_sha }}
-        run: |
-          set -euo pipefail
-          proceed=false
-          # Xcode Cloud reports its workflow checks as "Xcode Cloud / <Workflow Name>".
-          # Match the prefix + the exact ship workflow name we configured in ASC.
-          if [ "$BRANCH" = "main" ] \
-             && [[ "$CHECK_NAME" =~ ^Xcode\ Cloud[[:space:]]*/[[:space:]]*Ship\ to\ TestFlight$ ]]; then
-            proceed=true
-          fi
-          {
-            echo "proceed=$proceed"
-            echo "main_sha=$HEAD_SHA"
-            echo "check_conclusion=$CHECK_CONCLUSION"
-            echo "check_details_url=$CHECK_DETAILS_URL"
-          } >> "$GITHUB_OUTPUT"
-
   finalize:
-    needs: resolve
-    if: needs.resolve.outputs.proceed == 'true'
     runs-on: ubuntu-latest
     concurrency:
-      group: tf-ship-finalize-${{ needs.resolve.outputs.main_sha }}
+      group: tf-ship-finalize-${{ inputs.main_sha }}
       cancel-in-progress: false
     permissions:
       contents: read
@@ -72,10 +47,10 @@ jobs:
           set -euo pipefail
           # The action's default `claude_code` system-prompt preset reads
           # markdown specs as docs/role-assignment unless an imperative
-          # directive opens the user message. See debug/tf-triage-diagnostics.
+          # directive opens the user message.
           {
             echo 'content<<PROMPT_EOF'
-            echo 'Execute the SHIP-FINALIZE routine described below right now on the check_run that fired this workflow (env vars CHECK_CONCLUSION, CHECK_DETAILS_URL, CHECK_NAME, COMMIT_SHA). Use the available tools (Bash, Read, Grep, Glob) as needed. Do not ask for confirmation. End with the summary line specified in the routine.'
+            echo 'Execute the SHIP-FINALIZE routine described below right now on the check_run that fired this workflow (env vars CHECK_CONCLUSION, CHECK_DETAILS_URL, CHECK_NAME, MAIN_SHA). Use the available tools (Bash, Read, Grep, Glob) as needed. Do not ask for confirmation. End with the summary line specified in the routine.'
             echo
             echo '---'
             echo
@@ -89,9 +64,10 @@ jobs:
         uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MAIN_SHA: ${{ needs.resolve.outputs.main_sha }}
-          CHECK_CONCLUSION: ${{ needs.resolve.outputs.check_conclusion }}
-          CHECK_DETAILS_URL: ${{ needs.resolve.outputs.check_details_url }}
+          MAIN_SHA: ${{ inputs.main_sha }}
+          CHECK_CONCLUSION: ${{ inputs.check_conclusion }}
+          CHECK_DETAILS_URL: ${{ inputs.check_details_url }}
+          CHECK_NAME: ${{ inputs.check_name }}
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
           ASC_PRIVATE_KEY: ${{ secrets.ASC_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
\`anthropics/claude-code-action@v1\` throws **\`Unsupported event type: check_run\`** at \`parseGitHubContext\`. Verified on PR #33 — autofix run 24960080959 reached the action, then exited 1.

So even after the previous fix accepted \`action_required\` and pulled the right BRANCH, the autofix never actually ran. Tests broken on autofix/issue-30 → no iteration.

## Fix
Split each check_run-driven workflow in two:

| Bridge | Triggers | Work |
|---|---|---|
| \`tf-autofix-bridge.yml\` | \`check_run.completed\` | Resolves \`autofix/issue-N\` + terminal conclusion → \`gh workflow run tf-autofix.yml\` |
| \`tf-autofix.yml\` | \`issues.labeled\`, \`workflow_dispatch\` | Runs Claude |
| \`tf-ship-finalize-bridge.yml\` | \`check_run.completed\` | Resolves \`main\` + Ship-to-TestFlight name → \`gh workflow run tf-ship-finalize.yml\` |
| \`tf-ship-finalize.yml\` | \`workflow_dispatch\` | Runs Claude |

Bridges have only \`actions: write + contents: read\`. No Claude invocation, no OAuth cost.

## Also (out-of-band)
Patched the Xcode Cloud PR Build & Test + Ship to TestFlight workflows' \`filesAndFoldersRule\` via ASC API to actually skip Apple-irrelevant PRs. Apple's \`directory\` matcher is **non-recursive** — \`.github\` did not match \`.github/workflows/foo.yml\`, which is why PR #28 (100% workflow YAML) still ran Apple builds. New rule: explicit subdir matchers (\`.github/workflows\`, \`.claude/routines\`, etc) + fileExtension fallbacks (yml/yaml/md). Rule lives server-side; not in this repo.

## Test plan
- [ ] After merge: \`check_run.completed\` for an Xcode Cloud action on \`autofix/issue-N\` → \`tf-autofix-bridge\` proceeds → \`tf-autofix\` runs Claude end-to-end (no "Unsupported event type" error).
- [ ] Push a tiny .md-only commit on a feature branch → Xcode Cloud PR workflow should NOT fire.