### PR TITLE
ci: allow github-actions[bot] on bridge-dispatched workflows

### DIFF
--- a/.github/workflows/tf-autofix.yml
+++ b/.github/workflows/tf-autofix.yml
@@ -149,6 +149,10 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # tf-autofix-bridge.yml dispatches this workflow via `gh workflow
+          # run`, which sets the actor to github-actions[bot]. Without this
+          # the action rejects the run as "non-human actor".
+          allowed_bots: "github-actions"
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: |
             --model claude-opus-4-7[1m]

--- a/.github/workflows/tf-ship-finalize.yml
+++ b/.github/workflows/tf-ship-finalize.yml
@@ -75,6 +75,9 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # tf-ship-finalize-bridge.yml dispatches this workflow via `gh
+          # workflow run`, which sets the actor to github-actions[bot].
+          allowed_bots: "github-actions"
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: |
             --model claude-opus-4-7[1m]


### PR DESCRIPTION
Bridge dispatches set actor=github-actions[bot]; claude-code-action then rejects with "non-human actor". Allow specifically that bot (not `*`).