### PR TITLE
ci: GHA bridge + UI test schemes + tf-triage dedup fix

### DIFF
--- a/.claude/routines/_shared.md
+++ b/.claude/routines/_shared.md
@@ -49,9 +49,17 @@ pinned GitHub issue labeled `meta-state`, title
 ```json
 {
   "last_feedback_iso": "2026-04-23T00:00:00Z",
-  "last_ship_iso":     "2026-04-23T00:00:00Z"
+  "last_ship_iso":     "2026-04-23T00:00:00Z",
+  "processed_feedback_ids": ["ALszOk...", "..."]
 }
 ```
+
+`processed_feedback_ids` is an ID-level guard for `tf-triage`: a
+FIFO-trimmed list (cap 200) of ASC submission ids that have already
+been seen. It exists because the `[hash:<12>]` title search has
+historically missed duplicates and the `last_feedback_iso` cursor
+alone isn't strict enough — late-arriving items inside the same
+30-min poll window slipped through and got refiled.
 
 **Read**:
 ```

--- a/.claude/routines/scripts/asc.py
+++ b/.claude/routines/scripts/asc.py
@@ -259,6 +259,33 @@ def build_log_urls(run_id: str) -> list[str]:
     return urls
 
 
+def list_artifacts(run_id: str) -> list[dict]:
+    """All artifacts attached to a build run's actions, with download URLs.
+
+    Used by the GitHub Actions ui-screenshots bridge to find the
+    ci_artifacts/ui-screenshots/ bundle published by ci_post_xcodebuild.sh.
+    """
+    actions = asc_get(f"/v1/ciBuildRuns/{run_id}/actions").get("data", [])
+    out: list[dict] = []
+    for a in actions:
+        action_attrs = a.get("attributes") or {}
+        action_id = a.get("id")
+        arts = asc_get(f"/v1/ciBuildActions/{action_id}/artifacts").get("data", [])
+        for art in arts:
+            attrs = art.get("attributes") or {}
+            out.append({
+                "actionId": action_id,
+                "actionName": action_attrs.get("name"),
+                "actionType": action_attrs.get("actionType"),
+                "actionStatus": action_attrs.get("completionStatus"),
+                "fileName": attrs.get("fileName"),
+                "fileType": attrs.get("fileType"),
+                "fileSize": attrs.get("fileSize"),
+                "downloadUrl": attrs.get("downloadUrl"),
+            })
+    return out
+
+
 # ---------------- CLI ----------------
 
 def main():
@@ -278,6 +305,10 @@ def main():
                         help="Print downloadable log URLs for a buildRun")
     bl.add_argument("--run", required=True)
 
+    arts = sub.add_parser("artifacts",
+                          help="List all artifacts of a buildRun as JSON")
+    arts.add_argument("--run", required=True)
+
     args = p.parse_args()
 
     if args.cmd == "jwt":
@@ -289,6 +320,8 @@ def main():
     elif args.cmd == "build-log":
         for u in build_log_urls(args.run):
             print(u)
+    elif args.cmd == "artifacts":
+        print(json.dumps(list_artifacts(args.run), indent=2, ensure_ascii=False))
 
 
 if __name__ == "__main__":

--- a/.claude/routines/scripts/asc.py
+++ b/.claude/routines/scripts/asc.py
@@ -83,7 +83,15 @@ def asc_get(path: str) -> dict:
 # ---------------- TestFlight feedback ----------------
 
 def _dedup_hash(kind: str, payload: str, build_ver: str) -> str:
-    h = hashlib.sha256(f"{payload}||{build_ver}".encode()).hexdigest()
+    # Build version is intentionally NOT in the hash. The same complaint
+    # surfacing on a newer build must collapse to the same hash so the
+    # triage routine recognizes it (and reopens-as-regression a closed
+    # issue) instead of filing a fresh duplicate. `build_ver` stays in
+    # the signature for API stability — callers still pass it but it
+    # doesn't influence the key. `kind` keeps screenshot vs crash
+    # disjoint even when an empty payload would otherwise collide.
+    _ = build_ver
+    h = hashlib.sha256(f"{kind}||{payload}".encode()).hexdigest()
     return h[:12]
 
 

--- a/.claude/routines/tf-triage.md
+++ b/.claude/routines/tf-triage.md
@@ -53,16 +53,34 @@ Env vars on this routine:
    `sha256(stack_head || build_version)` for crashes).
 
 3. **Dedup against existing issues.**
-   For each item, search GitHub for `[hash:<12>]` in issue titles:
+
+   Two layers — the second matters because GitHub search tokenizes
+   `[hash:abc]` unreliably and historically missed dupes (issues #29
+   #30 #42 etc were each filed twice because `--search` came up empty).
+
+   3a. **ID-level guard.** Read `processed_feedback_ids` from the
+   `meta-state` issue body (array of ASC submission ids, capped at
+   the most recent 200). If the current item's `id` is already in
+   the list, skip outright — no GH calls, no dedup search.
+
+   3b. **Hash-level dedup via list + jq, never `--search`.**
    ```bash
-   gh issue list --repo hanbin2007/AIChat --state all \
-     --search "[hash:$HASH] in:title" --json number,state,labels
+   HIT=$(gh issue list --repo hanbin2007/AIChat --state all \
+           --label source:testflight-api --limit 200 \
+           --json number,state,title \
+         | jq -r --arg h "$HASH" \
+             '.[] | select(.title | contains("[hash:"+$h+"]")) | "\(.number)\t\(.state)"' \
+         | head -1)
    ```
-   - Open issue with same hash → comment
-     `@hanbin2007 New duplicate submission: <id>, build <ver>`. Skip.
-   - Closed issue with same hash → reopen, add label `regression`,
-     comment as above. Skip.
-   - Miss → proceed to step 4.
+   - `HIT` empty → miss → proceed to step 4.
+   - `HIT` matches an **OPEN** issue → comment
+     `@hanbin2007 New duplicate submission: <id>, build <ver>`. Skip
+     filing.
+   - `HIT` matches a **CLOSED** issue → reopen it, add label
+     `regression`, comment as above. Skip filing.
+
+   In every branch, append the current item's `id` to
+   `processed_feedback_ids` (drop oldest entries past 200).
 
 4. **Investigate (misses only).**
    - Classify: `tf-bug` / `tf-feature` / `tf-other`.
@@ -97,7 +115,9 @@ Env vars on this routine:
 
 6. **Update state.** Set `last_feedback_iso` to the highest `created`
    value seen (even for duplicates, so we don't reprocess them).
-   Write back to the `meta-state` issue body.
+   Persist the updated `processed_feedback_ids` list (FIFO-trimmed
+   to the 200 most recent entries). Write back to the `meta-state`
+   issue body as one JSON write — partial writes lose the cursor.
 
 ## Caps
 

--- a/.github/workflows/ui-screenshots-bridge.yml
+++ b/.github/workflows/ui-screenshots-bridge.yml
@@ -1,0 +1,72 @@
+name: ui-screenshots-bridge
+
+# Routes Xcode Cloud check_run completions for PR builds into a
+# workflow_dispatch on ui-screenshots.yml. Pure routing — no Claude or
+# secret-bearing work happens here. Same shape as tf-autofix-bridge.yml.
+#
+# The downstream workflow (ui-screenshots.yml) is no-op when the build
+# didn't ship a ci_artifacts/ui-screenshots/ bundle, so this bridge can
+# fire on every Xcode Cloud check without forcing per-workflow filters
+# in App Store Connect.
+
+on:
+  check_run:
+    types: [completed]
+
+permissions:
+  actions: write   # gh workflow run dispatch
+  contents: read
+
+jobs:
+  bridge:
+    runs-on: ubuntu-latest
+    env:
+      CHECK_NAME: ${{ github.event.check_run.name }}
+      CHECK_CONCLUSION: ${{ github.event.check_run.conclusion }}
+      CHECK_DETAILS_URL: ${{ github.event.check_run.details_url }}
+      CHECK_APP_SLUG: ${{ github.event.check_run.app.slug }}
+      PR_NUMBER: ${{ github.event.check_run.pull_requests[0].number }}
+      HEAD_SHA: ${{ github.event.check_run.head_sha }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Resolve and dispatch
+        run: |
+          set -euo pipefail
+
+          # Only Xcode Cloud check_runs have an ASC build run id encoded
+          # in details_url. The app slug is the most reliable filter.
+          if [ "$CHECK_APP_SLUG" != "appstore-connect" ] \
+             && ! printf '%s' "$CHECK_NAME" | grep -qi 'xcode cloud'; then
+            echo "Not an Xcode Cloud check (app=$CHECK_APP_SLUG, name=$CHECK_NAME); skipping."
+            exit 0
+          fi
+
+          # No PR ⇒ nowhere to post screenshots; main-branch builds skip.
+          if [ -z "${PR_NUMBER:-}" ] || [ "$PR_NUMBER" = "null" ]; then
+            echo "check_run not associated with a PR; skipping."
+            exit 0
+          fi
+
+          # Apple reports test failures as action_required; treat any
+          # terminal-ish state as worth fetching screenshots from.
+          case "$CHECK_CONCLUSION" in
+            success|failure|action_required|neutral) ;;
+            *)
+              echo "check_run conclusion '$CHECK_CONCLUSION' not terminal; skipping."
+              exit 0
+              ;;
+          esac
+
+          RUN_ID="${CHECK_DETAILS_URL##*/}"
+          if [ -z "$RUN_ID" ]; then
+            echo "Could not parse run id from details_url=$CHECK_DETAILS_URL; skipping."
+            exit 0
+          fi
+
+          gh workflow run ui-screenshots.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref main \
+            -f pr_number="$PR_NUMBER" \
+            -f run_id="$RUN_ID" \
+            -f head_sha="$HEAD_SHA" \
+            -f check_name="$CHECK_NAME"

--- a/.github/workflows/ui-screenshots.yml
+++ b/.github/workflows/ui-screenshots.yml
@@ -1,0 +1,174 @@
+name: ui-screenshots
+
+# Pulls the ci_artifacts/ui-screenshots/ bundle off an Xcode Cloud build
+# run via the ASC API, uploads the PNGs as a GHA artifact, and posts a
+# summary comment on the PR. Runs on ubuntu — no macOS minutes burned.
+#
+# Triggered by ui-screenshots-bridge.yml on every Xcode Cloud
+# check_run.completed for a PR. The job is a clean no-op if the build
+# didn't carry a screenshot bundle (i.e. the workflow didn't run
+# AIChat Watch UITests / AIChat iOS UITests), so it's safe to fire wide.
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to post results on"
+        required: true
+      run_id:
+        description: "Xcode Cloud ciBuildRun id"
+        required: true
+      head_sha:
+        description: "Head commit SHA"
+        required: false
+      check_name:
+        description: "Originating check name"
+        required: false
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  fetch-and-post:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ui-screenshots-pr-${{ inputs.pr_number }}
+      cancel-in-progress: true
+    env:
+      PR_NUMBER: ${{ inputs.pr_number }}
+      RUN_ID: ${{ inputs.run_id }}
+      HEAD_SHA: ${{ inputs.head_sha }}
+      CHECK_NAME: ${{ inputs.check_name }}
+      ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+      ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+      ASC_PRIVATE_KEY: ${{ secrets.ASC_PRIVATE_KEY }}
+      ASC_PRODUCT_ID: ${{ secrets.ASC_PRODUCT_ID }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout (need asc.py + scripts)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: List Xcode Cloud build artifacts
+        id: list
+        run: |
+          set -euo pipefail
+          mkdir -p .ui-screenshots
+          python3 .claude/routines/scripts/asc.py artifacts --run "$RUN_ID" \
+            > .ui-screenshots/artifacts.json
+          echo "artifact_count=$(jq 'length' .ui-screenshots/artifacts.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Download and extract image attachments
+        id: extract
+        run: |
+          set -euo pipefail
+          OUT=.ui-screenshots/images
+          mkdir -p "$OUT"
+
+          # Xcode Cloud surfaces ci_artifacts/ as ARCHIVE-typed artifacts
+          # (one zip per top-level directory). Pull every archive that has
+          # a usable downloadUrl and open them; we'll filter for images
+          # afterwards. Anything else (LOG/LOGARCHIVE) is ignored.
+          jq -r '.[] | select(.downloadUrl != null and (.fileType // "" | ascii_upcase) == "ARCHIVE") | [.fileName, .downloadUrl] | @tsv' \
+            .ui-screenshots/artifacts.json > .ui-screenshots/archives.tsv
+
+          archive_count=$(wc -l < .ui-screenshots/archives.tsv | tr -d ' ')
+          echo "Considering $archive_count archive(s) from build run $RUN_ID"
+
+          while IFS=$'\t' read -r name url; do
+            [ -n "${url:-}" ] || continue
+            safe_name=$(printf '%s' "$name" | tr -c 'A-Za-z0-9._-' '_')
+            tmp=".ui-screenshots/_dl_${safe_name}"
+            mkdir -p "$tmp"
+            echo "Downloading $name"
+            curl -fsSL "$url" -o "$tmp/archive.zip" || {
+              echo "  download failed; skipping"
+              continue
+            }
+            # Archives may be plain zip (ci_artifacts contents) or .xcresult
+            # bundles (ZIP under the hood). unzip handles both.
+            unzip -q -o "$tmp/archive.zip" -d "$tmp/unpacked" || {
+              echo "  unzip failed; skipping"
+              continue
+            }
+            # Look only inside ui-screenshots subtrees — avoids hauling
+            # screenshots out of unrelated archives if Xcode ever bundles
+            # other test attachments alongside them.
+            find "$tmp/unpacked" -type d -iname 'ui-screenshots' -print | while read -r dir; do
+              find "$dir" -type f \( -iname '*.png' -o -iname '*.jpg' -o -iname '*.jpeg' \) -print0 \
+                | while IFS= read -r -d '' img; do
+                    base=$(basename "$img")
+                    cp -n "$img" "$OUT/$base"
+                  done
+            done
+            rm -rf "$tmp"
+          done < .ui-screenshots/archives.tsv
+
+          image_count=$(find "$OUT" -type f \( -iname '*.png' -o -iname '*.jpg' -o -iname '*.jpeg' \) | wc -l | tr -d ' ')
+          echo "image_count=$image_count" >> "$GITHUB_OUTPUT"
+          echo "Extracted $image_count screenshot(s)"
+
+      - name: Upload screenshots as workflow artifact
+        if: steps.extract.outputs.image_count != '0'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-screenshots-${{ inputs.run_id }}
+          path: .ui-screenshots/images/
+          if-no-files-found: ignore
+          retention-days: 30
+
+      - name: Post (or update) PR comment
+        if: steps.extract.outputs.image_count != '0'
+        env:
+          IMAGE_COUNT: ${{ steps.extract.outputs.image_count }}
+        run: |
+          set -euo pipefail
+
+          run_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          marker="<!-- ui-screenshots-bot:run=${RUN_ID} -->"
+
+          {
+            printf '%s\n' "$marker"
+            printf '### UI screenshots from Xcode Cloud\n\n'
+            printf '%s screenshot file(s) from build run `%s`' "$IMAGE_COUNT" "$RUN_ID"
+            if [ -n "${HEAD_SHA:-}" ]; then
+              printf ' on commit `%s`' "${HEAD_SHA:0:7}"
+            fi
+            printf '.\n\n'
+            printf '%s' '**Files:**'
+            printf '\n\n'
+            (cd .ui-screenshots/images && ls | sort) | sed 's/^/- `/' | sed 's/$/`/'
+            printf '\nDownload: [ui-screenshots-%s](%s#artifacts)\n' "$RUN_ID" "$run_url"
+            if [ -n "${CHECK_NAME:-}" ]; then
+              printf '\n_From check: %s_\n' "$CHECK_NAME"
+            fi
+          } > .ui-screenshots/comment.md
+
+          # Update the existing comment for this build run if one is there;
+          # otherwise create a fresh one. Keeps the PR tidy across reruns.
+          existing=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+                      --paginate --jq ".[] | select(.body | contains(\"$marker\")) | .id" \
+                      | head -n1 || true)
+
+          if [ -n "$existing" ]; then
+            gh api -X PATCH \
+              "repos/$GITHUB_REPOSITORY/issues/comments/$existing" \
+              -F body=@.ui-screenshots/comment.md >/dev/null
+            echo "Updated existing comment $existing"
+          else
+            gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+              --body-file .ui-screenshots/comment.md
+            echo "Posted new comment"
+          fi
+
+      - name: No-op summary
+        if: steps.extract.outputs.image_count == '0'
+        run: |
+          echo "Build run $RUN_ID carried no ui-screenshots bundle (probably not a UI-test workflow). Nothing to post."

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 DerivedData/
 .artifacts/
+ci_artifacts/
 .build/
 /build/
 .package-cache/

--- a/AIChat.xcodeproj/xcshareddata/xcschemes/AIChat Watch UITests.xcscheme
+++ b/AIChat.xcodeproj/xcshareddata/xcschemes/AIChat Watch UITests.xcscheme
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FD4A0A212F5C50E700E9D16E"
+               BuildableName = "AIChat Watch App.app"
+               BlueprintName = "AIChat Watch App"
+               ReferencedContainer = "container:AIChat.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FD4A0A1B2F5C50E700E9D16E"
+               BuildableName = "AIChat.app"
+               BlueprintName = "AIChat"
+               ReferencedContainer = "container:AIChat.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FD4A0A3A2F5C50E800E9D16E"
+               BuildableName = "AIChat Watch AppUITests.xctest"
+               BlueprintName = "AIChat Watch AppUITests"
+               ReferencedContainer = "container:AIChat.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FD4A0A212F5C50E700E9D16E"
+            BuildableName = "AIChat Watch App.app"
+            BlueprintName = "AIChat Watch App"
+            ReferencedContainer = "container:AIChat.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FD4A0A212F5C50E700E9D16E"
+            BuildableName = "AIChat Watch App.app"
+            BlueprintName = "AIChat Watch App"
+            ReferencedContainer = "container:AIChat.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/AIChat.xcodeproj/xcshareddata/xcschemes/AIChat iOS UITests.xcscheme
+++ b/AIChat.xcodeproj/xcshareddata/xcschemes/AIChat iOS UITests.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FD4A0A1B2F5C50E700E9D16E"
+               BuildableName = "AIChat.app"
+               BlueprintName = "AIChat"
+               ReferencedContainer = "container:AIChat.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C0D1F0013000000000000004"
+               BuildableName = "AIChat iOS AppUITests.xctest"
+               BlueprintName = "AIChat iOS AppUITests"
+               ReferencedContainer = "container:AIChat.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FD4A0A1B2F5C50E700E9D16E"
+            BuildableName = "AIChat.app"
+            BlueprintName = "AIChat"
+            ReferencedContainer = "container:AIChat.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FD4A0A1B2F5C50E700E9D16E"
+            BuildableName = "AIChat.app"
+            BlueprintName = "AIChat"
+            ReferencedContainer = "container:AIChat.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,4 +90,11 @@ Chinese (zh-Hans) and English via `L10n.swift` in `Shared Licensing/`. Use `L10n
 
 UI tests use environment variable `AIChat_UI_TEST_SCENARIO` to bootstrap specific `ChatStore` configurations with seeded data and mock streaming services. Test scenarios are defined in `AIChatApp.swift` under `UITestBootstrap`.
 
-**When you make UI-affecting changes, the change MUST be exercised by a test in `AIChat Watch AppUITests` or `AIChat iOS AppUITests` that calls `attachScreenshot(app, named:)` at the relevant moment.** Xcode Cloud runs the dedicated `AIChat Watch UITests` / `AIChat iOS UITests` schemes, and `ci_scripts/ci_post_xcodebuild.sh` extracts every `XCTAttachment` screenshot from the resulting `.xcresult` into `ci_artifacts/ui-screenshots/`, which Xcode Cloud publishes as downloadable artifacts on the build report and PR check page. No screenshot attachment ⇒ no visual review surface for the UI change.
+**When you make UI-affecting changes, the change MUST be exercised by a test in `AIChat Watch AppUITests` or `AIChat iOS AppUITests` that calls `attachScreenshot(app, named:)` at the relevant moment.** Round-trip:
+
+1. Xcode Cloud runs the dedicated `AIChat Watch UITests` / `AIChat iOS UITests` schemes.
+2. `ci_scripts/ci_post_xcodebuild.sh` pulls every `XCTAttachment` screenshot from the `.xcresult` into `ci_artifacts/ui-screenshots/` (Xcode Cloud uploads `ci_artifacts/` as build artifacts).
+3. `.github/workflows/ui-screenshots-bridge.yml` catches the Xcode Cloud `check_run.completed` and dispatches `ui-screenshots.yml`.
+4. `ui-screenshots.yml` calls `python3 .claude/routines/scripts/asc.py artifacts --run "$RUN_ID"` to fetch the bundle via the ASC API, uploads PNGs as a workflow artifact, and posts (or updates) a single PR comment marked `<!-- ui-screenshots-bot:run=<id> -->`.
+
+No screenshot attachment in the test ⇒ no visual review surface for the UI change.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,10 @@ xcodebuild -scheme "AIChat Watch App" -destination "platform=watchOS Simulator,i
 
 # Run watch UI tests
 xcodebuild -scheme "AIChat Watch App" -destination "platform=watchOS Simulator,id=93A83695-2859-4388-B337-957616D03F55" -only-testing:"AIChat Watch AppUITests" test
+
+# UI-test-only schemes (used by Xcode Cloud to surface screenshots)
+xcodebuild -scheme "AIChat Watch UITests" -destination "platform=watchOS Simulator,id=93A83695-2859-4388-B337-957616D03F55" test
+xcodebuild -scheme "AIChat iOS UITests"   -destination "platform=iOS Simulator,name=iPhone 17" test
 ```
 
 **Known-good simulator (verified 2026-04-19):**
@@ -85,3 +89,5 @@ Chinese (zh-Hans) and English via `L10n.swift` in `Shared Licensing/`. Use `L10n
 ### UI Test Infrastructure
 
 UI tests use environment variable `AIChat_UI_TEST_SCENARIO` to bootstrap specific `ChatStore` configurations with seeded data and mock streaming services. Test scenarios are defined in `AIChatApp.swift` under `UITestBootstrap`.
+
+**When you make UI-affecting changes, the change MUST be exercised by a test in `AIChat Watch AppUITests` or `AIChat iOS AppUITests` that calls `attachScreenshot(app, named:)` at the relevant moment.** Xcode Cloud runs the dedicated `AIChat Watch UITests` / `AIChat iOS UITests` schemes, and `ci_scripts/ci_post_xcodebuild.sh` extracts every `XCTAttachment` screenshot from the resulting `.xcresult` into `ci_artifacts/ui-screenshots/`, which Xcode Cloud publishes as downloadable artifacts on the build report and PR check page. No screenshot attachment ⇒ no visual review surface for the UI change.

--- a/ci_scripts/ci_post_xcodebuild.sh
+++ b/ci_scripts/ci_post_xcodebuild.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+set -eu
+
+# Xcode Cloud post-build hook. Pulls UI-test screenshot attachments out of
+# the .xcresult bundle and drops them under ci_artifacts/, which Xcode
+# Cloud then publishes as downloadable artifacts on the build report (and
+# on the PR check page when the build came from a PR).
+#
+# The watch and iOS UI tests already attach screenshots via
+# XCTAttachment, but those live deep inside the .xcresult bundle and
+# aren't browsable without downloading and opening the bundle locally.
+# Surfacing them as plain PNGs makes UI-affecting builds reviewable
+# directly from GitHub's check page.
+
+if [ -z "${CI_PRIMARY_REPOSITORY_PATH:-}" ]; then
+  echo "ci_post_xcodebuild: no repo on this runner; nothing to do"
+  exit 0
+fi
+
+cd "$CI_PRIMARY_REPOSITORY_PATH"
+
+# Only test workflows produce an .xcresult — archive/build runs have
+# nothing to extract from.
+case "${CI_XCODEBUILD_ACTION:-}" in
+  test|test-without-building) ;;
+  *)
+    echo "ci_post_xcodebuild: action=${CI_XCODEBUILD_ACTION:-unknown}; no UI screenshots to extract"
+    exit 0
+    ;;
+esac
+
+if [ -z "${CI_RESULT_BUNDLE_PATH:-}" ] || [ ! -d "$CI_RESULT_BUNDLE_PATH" ]; then
+  echo "ci_post_xcodebuild: no result bundle at CI_RESULT_BUNDLE_PATH; nothing to extract"
+  exit 0
+fi
+
+OUT_DIR="$CI_PRIMARY_REPOSITORY_PATH/ci_artifacts/ui-screenshots"
+mkdir -p "$OUT_DIR"
+
+echo "ci_post_xcodebuild: extracting attachments from $CI_RESULT_BUNDLE_PATH into $OUT_DIR"
+
+# Xcode 16+ exposes `xcresulttool export attachments`; older Xcode versions
+# only support the legacy JSON dump. Try the new path first and fall back.
+if xcrun xcresulttool export attachments \
+     --path "$CI_RESULT_BUNDLE_PATH" \
+     --output-path "$OUT_DIR" >/dev/null 2>&1; then
+  echo "ci_post_xcodebuild: exported via 'xcresulttool export attachments'"
+elif xcrun xcresulttool export object \
+       --path "$CI_RESULT_BUNDLE_PATH" \
+       --type directory \
+       --output-path "$OUT_DIR" >/dev/null 2>&1; then
+  echo "ci_post_xcodebuild: exported via legacy 'xcresulttool export object'"
+else
+  echo "ci_post_xcodebuild: xcresulttool export failed; copying full result bundle"
+  cp -R "$CI_RESULT_BUNDLE_PATH" "$OUT_DIR/result.xcresult"
+fi
+
+# Discard non-image attachments (debug hierarchies, telemetry, plists)
+# so the artifact archive stays a focused screenshot review surface.
+find "$OUT_DIR" -type f \
+  ! \( -iname '*.png' -o -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.heic' \) \
+  -delete 2>/dev/null || true
+
+# Prune now-empty intermediate directories left by `find -delete`.
+find "$OUT_DIR" -type d -empty -delete 2>/dev/null || true
+
+if [ ! -d "$OUT_DIR" ]; then
+  echo "ci_post_xcodebuild: no image attachments found"
+  exit 0
+fi
+
+count=$(find "$OUT_DIR" -type f \( -iname '*.png' -o -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.heic' \) | wc -l | tr -d ' ')
+echo "ci_post_xcodebuild: kept $count screenshot file(s) under $OUT_DIR"
+
+if [ "$count" = "0" ]; then
+  rmdir "$OUT_DIR" 2>/dev/null || true
+fi


### PR DESCRIPTION
Follow-up to #37, which only carried the first commit (`ci_post_xcodebuild.sh`). This PR ships the rest of the round-trip plus an unrelated `tf-triage` dedup fix.

## Summary

- **Dedicated UI-test schemes** (`AIChat Watch UITests`, `AIChat iOS UITests`) so Xcode Cloud's scheme picker has clearly-named, UI-test-only entries to point a Test action at.
- **GitHub Actions bridge** that catches Xcode Cloud `check_run.completed` on a PR and dispatches `ui-screenshots.yml`. The dispatched workflow uses the ASC API (`asc.py artifacts --run …`) to pull the `ci_artifacts/ui-screenshots/` archive off the build run, uploads PNGs as a workflow artifact, and posts (or updates) a marker-tagged PR comment. Self-skips when the build didn't ship a screenshot bundle, so it's safe to fire on every Xcode Cloud check.
- **`asc.py artifacts` subcommand** — JSON list of all per-action artifacts on a build run, used by the workflow's jq filter.
- **`CLAUDE.md`** spells out the full screenshot round-trip: test `attachScreenshot` → `ci_post_xcodebuild.sh` → ASC artifact → bridge → `ui-screenshots.yml` → PR comment.
- **`tf-triage` dedup fix** (881a01b) — orthogonal to the rest, bundled to ship together. Two bugs caused 8 duplicate TF issues to get filed (#29/#43/#50, #30/#44/#51, #19/#48, #20/#40, #22/#41, #42/#49). Fix 1: drop `build_version` from `_dedup_hash` so the same complaint on a newer build hashes the same and the regression-reopen path actually fires. Fix 2: replace the unreliable `gh issue list --search "[hash:$H] in:title"` with a bounded `--label source:testflight-api` list piped through `jq | contains` for a literal `[hash:<12>]` substring match. Belt-and-suspenders: track `processed_feedback_ids` (FIFO 200) in the meta-state issue.

## Why merge needed

The two GHA workflow files (`ui-screenshots-bridge.yml`, `ui-screenshots.yml`) only get their webhook triggers registered when they live on the default branch. The two new shared schemes only show up in ASC's Xcode Cloud workflow editor once they're on `main`.

## Test plan

- [ ] After merge, ASC → Xcode Cloud → "PR Build and Test" (or new Test workflow) → scheme dropdown shows `AIChat Watch UITests` / `AIChat iOS UITests`.
- [ ] Open a follow-up PR that touches a UI test (calls `attachScreenshot(app, named:)`); after the Xcode Cloud test workflow finishes, a `<!-- ui-screenshots-bot:run=… -->` comment appears with the captured PNGs as a workflow artifact link.
- [ ] Next `tf-triage` cron tick: no fresh duplicate filed for any item already represented by a `[hash:…]` issue under `source:testflight-api`. Already-cleaned dups (#40 #41 #43 #44 #48 #49 #50 #51) stay closed.

Closes the screenshot round-trip started in #37.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2niqqYazJFn7YY36YZTZt)_