### PR TITLE
Fix relay mode access gating and credit deduction bugs

### DIFF
--- a/AIChat Watch App/Services/ActivationBillingService.swift
+++ b/AIChat Watch App/Services/ActivationBillingService.swift
@@ -70,6 +70,9 @@ final class ActivationBillingService: ObservableObject {
 
         switch account.state {
         case .active:
+            if let expiresAt = account.creditExpiresAt, expiresAt <= .now {
+                return "已过期"
+            }
             if account.creditBalance > 0 {
                 return "在线可用"
             }
@@ -108,21 +111,7 @@ final class ActivationBillingService: ObservableObject {
     }
 
     var hasManagedRelayAccess: Bool {
-        guard configuration.backendMode == .relay else {
-            return false
-        }
-
-        if configuration.relayBearerToken != nil {
-            return true
-        }
-
-        guard let account = relayAccountStatus?.account,
-              let key = relayAccountStatus?.key
-        else {
-            return false
-        }
-
-        return account.state == .active && key.state == .active && account.creditBalance > 0
+        isManagedRelayAccessActive(for: relayAccountStatus)
     }
 
     var isReadOnlyMode: Bool {
@@ -431,6 +420,9 @@ final class ActivationBillingService: ObservableObject {
 
             switch account.state {
             case .active:
+                if let expiresAt = account.creditExpiresAt, expiresAt <= .now {
+                    return "订阅或 credit 已过期。"
+                }
                 return account.creditBalance > 0 ? nil : "在线额度已用尽。"
             case .paused:
                 return "当前 relay key 已在服务端暂停。"
@@ -532,18 +524,21 @@ final class ActivationBillingService: ObservableObject {
         await shareManagedRelayAccessToCompanionIfPossible()
     }
 
-    private func isManagedRelayAccessActive(for status: RelayAccountStatusResponse?) -> Bool {
+    private func isManagedRelayAccessActive(
+        for status: RelayAccountStatusResponse?,
+        now: Date = .now
+    ) -> Bool {
         guard configuration.backendMode == .relay else {
             return false
-        }
-
-        if configuration.relayBearerToken != nil {
-            return true
         }
 
         guard let account = status?.account,
               let key = status?.key
         else {
+            return false
+        }
+
+        if let expiresAt = account.creditExpiresAt, expiresAt <= now {
             return false
         }
 

--- a/AIChat Watch App/Services/AppConfiguration.swift
+++ b/AIChat Watch App/Services/AppConfiguration.swift
@@ -263,7 +263,15 @@ nonisolated struct AppConfiguration: Equatable {
     }
 
     var resolvedRelayBearerToken: String? {
-        relayBearerToken ?? RelayAccessRepository.storedRelayKey(appGroupIdentifier: appGroupIdentifier)
+        // Online (relay) mode must authenticate as the user, so the server-issued
+        // key from the local store always wins. The xcconfig `relayBearerToken`
+        // is only honored as a fallback for the deprecated local Mac relay
+        // (where no per-user key exists); never let it shadow a real user key,
+        // otherwise account expiration and credit deduction get bypassed.
+        if let storedKey = RelayAccessRepository.storedRelayKey(appGroupIdentifier: appGroupIdentifier) {
+            return storedKey
+        }
+        return relayBearerToken
     }
 
     private var hasValidRelayBaseURL: Bool {

--- a/AIChat Watch App/ViewModels/ChatStore.swift
+++ b/AIChat Watch App/ViewModels/ChatStore.swift
@@ -2571,6 +2571,16 @@ final class ChatStore: ObservableObject {
                         await completionFeedbackProvider.notifyCompletion(of: .assistantReplyCompleted)
                     }
                 }
+
+                // Pull fresh account status so credit balance / expiry reflect
+                // the just-completed request. Server is the source of truth for
+                // deduction; the local cache would otherwise stay stale until
+                // the next launch.
+                if configuration.backendMode == .relay {
+                    Task { [weak self] in
+                        await self?.activationBilling.refreshActivationState()
+                    }
+                }
                 return
             } catch {
                 streamingPacer.cancel()

--- a/AIChat Watch AppTests/ActivationBillingServiceTests.swift
+++ b/AIChat Watch AppTests/ActivationBillingServiceTests.swift
@@ -1,0 +1,185 @@
+//
+//  ActivationBillingServiceTests.swift
+//  AIChat Watch AppTests
+//
+//  Regression tests for the relay-mode access gating, covering the bugs where
+//  expired keys still granted access and request credits were not deducted
+//  because the xcconfig bearer token bypassed all server-side validation.
+//
+
+import Foundation
+import XCTest
+@testable import AIChat_Watch_App
+
+@MainActor
+final class ActivationBillingServiceTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func makeRelayConfiguration(relayBearerToken: String? = nil) -> AppConfiguration {
+        AppConfiguration(
+            backendMode: .relay,
+            geminiAPIKey: nil,
+            geminiModel: "gemini-3-flash-preview",
+            geminiTranscriptionModel: "gemini-3-flash-preview",
+            relayBaseURL: URL(string: "http://127.0.0.1:8787"),
+            relayBearerToken: relayBearerToken,
+            relayStreamPath: "v1/chat/stream",
+            appGroupIdentifier: nil
+        )
+    }
+
+    private func makeService(relayBearerToken: String? = nil) -> ActivationBillingService {
+        let configuration = makeRelayConfiguration(relayBearerToken: relayBearerToken)
+        let rootURL = makeTemporaryRootURL(prefix: "AIChatTests-Billing")
+        return ActivationBillingService(
+            configuration: configuration,
+            deviceIdentity: WatchDeviceIdentity(
+                rawIdentifier: "test-device-\(UUID().uuidString)",
+                deviceToken: 0xDEAD_BEEF_CAFE_F00D,
+                displayToken: "TEST-TOKEN"
+            ),
+            activationRepository: ActivationRepository(configuration: configuration, rootURL: rootURL),
+            relayAccessRepository: RelayAccessRepository(configuration: configuration, rootURL: rootURL),
+            syncBridge: CompanionSyncBridge(isEnabled: false)
+        )
+    }
+
+    private func makeStatus(
+        accountState: RelayAccountState = .active,
+        keyState: RelayKeyState = .active,
+        creditBalance: Int = 100,
+        creditExpiresAt: Date? = nil
+    ) -> RelayAccountStatusResponse {
+        RelayAccountStatusResponse(
+            account: RelayAccountSummary(
+                accountID: UUID(),
+                displayName: nil,
+                adminNote: nil,
+                state: accountState,
+                source: .subscription,
+                planID: nil,
+                originalTransactionID: nil,
+                appAccountToken: nil,
+                creditBalance: creditBalance,
+                creditExpiresAt: creditExpiresAt,
+                lastUsageAt: nil
+            ),
+            device: nil,
+            key: RelayKeySummary(
+                keyID: UUID(),
+                keyValue: "server-issued-key",
+                state: keyState,
+                source: .subscription,
+                note: nil,
+                issuedAt: Date(timeIntervalSince1970: 0)
+            ),
+            grants: [],
+            recentUsage: []
+        )
+    }
+
+    // MARK: - hasManagedRelayAccess
+
+    /// Regression: previously `relayBearerToken != nil` short-circuited the
+    /// gate to `true`, letting the xcconfig dev/Mac-relay token grant access
+    /// even when no server-issued account existed. That caused expired keys
+    /// to keep working and credits to never be deducted (no user account on
+    /// the server to bill against).
+    func testHasManagedRelayAccessIsFalseWhenOnlyXcconfigBearerTokenIsSet() async {
+        let service = makeService(relayBearerToken: "xcconfig-admin-token")
+
+        // No relayAccountStatus has been fetched from the server yet.
+        XCTAssertNil(service.relayAccountStatus)
+        XCTAssertFalse(service.hasManagedRelayAccess)
+    }
+
+    func testHasManagedRelayAccessIsTrueForActiveServerStatus() async {
+        let service = makeService()
+        let status = makeStatus(
+            creditBalance: 500,
+            creditExpiresAt: Date().addingTimeInterval(3600)
+        )
+        await service.updateRelayAccountStatus(status, shareToCompanion: false)
+
+        XCTAssertTrue(service.hasManagedRelayAccess)
+    }
+
+    func testHasManagedRelayAccessIsFalseWhenCreditsHaveExpired() async {
+        let service = makeService()
+        let status = makeStatus(
+            creditBalance: 500,
+            // Server hasn't flipped state to `.expired` yet, but the credit
+            // window has lapsed — the client must still deny access.
+            creditExpiresAt: Date().addingTimeInterval(-60)
+        )
+        await service.updateRelayAccountStatus(status, shareToCompanion: false)
+
+        XCTAssertFalse(service.hasManagedRelayAccess)
+    }
+
+    func testHasManagedRelayAccessIsFalseWhenAccountStateIsNotActive() async {
+        let service = makeService()
+        let status = makeStatus(accountState: .expired, creditBalance: 500)
+        await service.updateRelayAccountStatus(status, shareToCompanion: false)
+
+        XCTAssertFalse(service.hasManagedRelayAccess)
+    }
+
+    func testHasManagedRelayAccessIsFalseWhenKeyStateIsNotActive() async {
+        let service = makeService()
+        let status = makeStatus(keyState: .paused, creditBalance: 500)
+        await service.updateRelayAccountStatus(status, shareToCompanion: false)
+
+        XCTAssertFalse(service.hasManagedRelayAccess)
+    }
+
+    func testHasManagedRelayAccessIsFalseWhenCreditBalanceIsZero() async {
+        let service = makeService()
+        let status = makeStatus(creditBalance: 0)
+        await service.updateRelayAccountStatus(status, shareToCompanion: false)
+
+        XCTAssertFalse(service.hasManagedRelayAccess)
+    }
+
+    // MARK: - Status title surfaces expiration
+
+    func testRelayAccessStatusTitleShowsExpiredEvenWhenStateIsActive() async {
+        let service = makeService()
+        let status = makeStatus(
+            accountState: .active,
+            creditBalance: 500,
+            creditExpiresAt: Date().addingTimeInterval(-60)
+        )
+        await service.updateRelayAccountStatus(status, shareToCompanion: false)
+
+        XCTAssertEqual(service.relayAccessStatusTitle, "已过期")
+    }
+
+    func testRelayAccessStatusTitleShowsAvailableWhenWithinExpiry() async {
+        let service = makeService()
+        let status = makeStatus(
+            creditBalance: 100,
+            creditExpiresAt: Date().addingTimeInterval(3600)
+        )
+        await service.updateRelayAccountStatus(status, shareToCompanion: false)
+
+        XCTAssertEqual(service.relayAccessStatusTitle, "在线可用")
+    }
+
+    // MARK: - Read-only mode follows managed access
+
+    func testIsReadOnlyModeIsTrueWhenRelayAccessExpiredAndNoOfflineActivation() async {
+        let service = makeService()
+        let status = makeStatus(
+            creditBalance: 500,
+            creditExpiresAt: Date().addingTimeInterval(-60)
+        )
+        await service.updateRelayAccountStatus(status, shareToCompanion: false)
+
+        // Expired credits → not managed, and no offline activation either,
+        // so the store should be locked into read-only.
+        XCTAssertFalse(service.hasManagedRelayAccess)
+        XCTAssertTrue(service.isReadOnlyMode)
+    }
+}


### PR DESCRIPTION
## Summary
This PR fixes critical security and billing bugs in relay mode where expired keys still granted access and request credits were not deducted. The root cause was that the xcconfig bearer token was bypassing all server-side validation.

## Key Changes

- **Fixed access gating logic**: Removed the short-circuit that allowed `relayBearerToken != nil` to grant access without server validation. Now `hasManagedRelayAccess` properly checks account status, key state, credit balance, and credit expiration.

- **Added credit expiration checks**: The client now validates that `creditExpiresAt` hasn't passed before granting access, even when the server hasn't flipped the account state to `.expired`. This prevents expired credits from continuing to work.

- **Fixed bearer token resolution priority**: Updated `resolvedRelayBearerToken` to always prefer the server-issued key from local storage over the xcconfig token. The xcconfig token is now only used as a fallback for the deprecated local Mac relay, never shadowing a real user key.

- **Added credit refresh after requests**: After completing a chat request in relay mode, the service now refreshes account status from the server to ensure credit balance and expiration reflect the just-completed deduction, preventing stale local cache.

- **Enhanced status messaging**: Updated `relayAccessStatusTitle` and error messages to surface credit expiration separately from account state, showing "已过期" (expired) when credits have expired even if the account state is still active.

## Testing
Added comprehensive regression test suite (`ActivationBillingServiceTests`) covering:
- Access denial when only xcconfig token is set (no server account)
- Access grant/denial based on account state, key state, credit balance, and expiration
- Status title correctly reflects expiration
- Read-only mode activation when access expires

https://claude.ai/code/session_018pBoynBC6wHwTB2nxuXqPW