### PR TITLE
fix(relay): gate rk_ auth and reserveCredits on account state + expiry

### DIFF
--- a/relay/src/lib/auth/bearer.ts
+++ b/relay/src/lib/auth/bearer.ts
@@ -36,10 +36,17 @@ export async function authenticate(request: Request): Promise<AuthContext | null
     return { kind: "admin", token, tokenLabel: match.label };
   }
 
-  // Per-device client key.
+  // Per-device client key. Both the key and its parent account must be
+  // active — otherwise an admin-paused or expired account would still
+  // pass auth as long as the key record itself wasn't flipped, and end
+  // up at reserveCredits where the account-level gates would reject it
+  // with a confusing 402 instead of a clean 401.
   if (token.startsWith("rk_")) {
     const key = await billingStore().findKeyByValue(token);
-    if (key && key.state === "active") return { kind: "client", token, clientKey: key };
+    if (!key || key.state !== "active") return null;
+    const account = await billingStore().findAccount(key.accountID);
+    if (!account || account.state !== "active") return null;
+    return { kind: "client", token, clientKey: key };
   }
   return null;
 }

--- a/relay/src/lib/store/billing-store.ts
+++ b/relay/src/lib/store/billing-store.ts
@@ -166,6 +166,12 @@ class BillingStore {
     return d ? clone(d) : undefined;
   }
 
+  async findAccount(accountID: string): Promise<Account | undefined> {
+    await this.ensureLoaded();
+    const a = this.state.accounts[accountID];
+    return a ? clone(a) : undefined;
+  }
+
   async getAccountStatus(key: Key): Promise<AccountStatusResponse | null> {
     await this.ensureLoaded();
     const acc = this.state.accounts[key.accountID];
@@ -542,6 +548,15 @@ class BillingStore {
     return this.write(() => {
       const account = this.state.accounts[params.key.accountID];
       if (!account) throw new Error("Account not found.");
+      if (account.state !== "active") {
+        throw Object.assign(new Error(`Account is ${account.state}.`), { statusCode: 402 });
+      }
+      // Time-based grant expiry. compact() zeros expired grants on the next
+      // write but reserveCredits reads creditBalance before that runs, so
+      // the first request after the deadline could otherwise slip through.
+      if (account.creditExpiresAt && new Date(account.creditExpiresAt).getTime() <= clockNow().getTime()) {
+        throw Object.assign(new Error("Credits expired."), { statusCode: 402 });
+      }
       const rate = rateForModel(this.state.policy, params.modelID);
       const reserved = creditsForUsage(this.state.policy, rate, {
         inputTokens: params.estimatedInputTokens,

--- a/relay/tests/unit/billing-gates.test.ts
+++ b/relay/tests/unit/billing-gates.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { authenticate } from "@/lib/auth/bearer";
+import { billingStore } from "@/lib/store/billing-store";
+import { resetClock, setClock } from "@/lib/clock";
+import { resetState } from "../helpers";
+
+/**
+ * Regression coverage for the relay billing gates added on top of the existing
+ * `kind: client` path:
+ *
+ * - `authenticate` rejects `rk_...` keys whose parent account is no longer
+ *   `active` (paused / expired / inactive). Previously only the key's own
+ *   `state` was checked, so an admin pausing the account at the account level
+ *   left the key still valid.
+ *
+ * - `reserveCredits` refuses to bill a non-active account or one whose
+ *   `creditExpiresAt` has lapsed. Previously only `creditBalance < reserved`
+ *   was guarded, so the first request after the deadline (before the next
+ *   `compact()` zeroed expired grants) could still slip through.
+ *
+ * Admin-token auth is intentionally untouched — the offline-activation flow
+ * relies on it for relaying without server-side credit accounting.
+ */
+describe("relay billing gates", () => {
+  beforeEach(resetState);
+  afterEach(resetClock);
+
+  // ---- authenticate (rk_ path) -----------------------------------------------
+
+  describe("authenticate", () => {
+    it("accepts an rk_ key whose key + account are both active", async () => {
+      const boot = await billingStore().bootstrapTrial({ deviceID: "auth-d1", platform: "watch" });
+      const req = new Request("http://test/x", {
+        headers: { Authorization: `Bearer ${boot.key.keyValue}` },
+      });
+      const auth = await authenticate(req);
+      expect(auth?.kind).toBe("client");
+      expect(auth?.clientKey?.keyValue).toBe(boot.key.keyValue);
+    });
+
+    it("rejects an rk_ key when the parent account is paused", async () => {
+      const boot = await billingStore().bootstrapTrial({ deviceID: "auth-d2", platform: "watch" });
+      await billingStore().modifyAccount(boot.account.accountID, { state: "paused" });
+      const req = new Request("http://test/x", {
+        headers: { Authorization: `Bearer ${boot.key.keyValue}` },
+      });
+      expect(await authenticate(req)).toBeNull();
+    });
+
+    it("rejects an rk_ key when the parent account is expired", async () => {
+      const boot = await billingStore().bootstrapTrial({ deviceID: "auth-d3", platform: "watch" });
+      await billingStore().modifyAccount(boot.account.accountID, { state: "expired" });
+      const req = new Request("http://test/x", {
+        headers: { Authorization: `Bearer ${boot.key.keyValue}` },
+      });
+      expect(await authenticate(req)).toBeNull();
+    });
+
+    it("still accepts the env admin bearer (offline-activation auth path)", async () => {
+      const req = new Request("http://test/x", {
+        headers: { Authorization: "Bearer test-bearer-token" },
+      });
+      const auth = await authenticate(req);
+      expect(auth?.kind).toBe("admin");
+    });
+  });
+
+  // ---- reserveCredits --------------------------------------------------------
+
+  describe("reserveCredits", () => {
+    it("throws 402 when the account is no longer active", async () => {
+      const boot = await billingStore().bootstrapTrial({ deviceID: "rsv-d1", platform: "watch" });
+      await billingStore().modifyAccount(boot.account.accountID, { state: "paused" });
+
+      await expect(
+        billingStore().reserveCredits({
+          key: boot.key,
+          endpoint: "/api/v1/chat/stream",
+          modelID: "gemini-3-flash-preview",
+          estimatedInputTokens: 1_000,
+          audioInput: false,
+        }),
+      ).rejects.toMatchObject({ statusCode: 402 });
+    });
+
+    it("throws 402 when account.creditExpiresAt has passed even with balance > 0", async () => {
+      // Bootstrap creates a trial grant with expiresAt ~30 days ahead, then we
+      // fast-forward the clock past it. compact() is called once on ensureLoaded
+      // (at "now") and zeros remainingCredits — but that runs at clock-1, so the
+      // bootstrap is fine. We then bump the clock past expiry but BEFORE another
+      // write, so creditExpiresAt is still on the cached account record. That's
+      // exactly the window the new gate needs to cover.
+      const t0 = new Date("2026-01-01T00:00:00Z");
+      setClock(() => t0);
+      const boot = await billingStore().bootstrapTrial({ deviceID: "rsv-d2", platform: "watch" });
+      expect(boot.account.creditBalance).toBeGreaterThan(0);
+      expect(boot.account.creditExpiresAt).toBeDefined();
+
+      // Jump to one minute past the trial's expiresAt.
+      const t1 = new Date(new Date(boot.account.creditExpiresAt!).getTime() + 60_000);
+      setClock(() => t1);
+
+      await expect(
+        billingStore().reserveCredits({
+          key: boot.key,
+          endpoint: "/api/v1/chat/stream",
+          modelID: "gemini-3-flash-preview",
+          estimatedInputTokens: 1_000,
+          audioInput: false,
+        }),
+      ).rejects.toMatchObject({ statusCode: 402 });
+    });
+
+    it("succeeds while creditExpiresAt is still in the future", async () => {
+      const t0 = new Date("2026-01-01T00:00:00Z");
+      setClock(() => t0);
+      const boot = await billingStore().bootstrapTrial({ deviceID: "rsv-d3", platform: "watch" });
+
+      const record = await billingStore().reserveCredits({
+        key: boot.key,
+        endpoint: "/api/v1/chat/stream",
+        modelID: "gemini-3-flash-preview",
+        estimatedInputTokens: 1_000,
+        audioInput: false,
+      });
+      expect(record.reservedCredits).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Hardens the relay's `rk_...` (per-user client key) path so that account state and time-based credit expiry are enforced at auth time and at credit reservation time. The admin-bearer path is intentionally untouched — the watch app's offline-activation flow relies on it for relaying without server-side credit accounting.

## Why

Two gaps surfaced while diagnosing "credits not deducted" reports on the iOS side (companion fix in #58):

1. **Auth only checked the key's own state.** `authenticate()` for `rk_...` tokens validated `key.state === "active"` but never consulted the parent account. Pausing or expiring an account from the admin UI did not stop inbound traffic — the key kept passing auth as long as its own state hadn't been flipped, and the request landed at `reserveCredits` where it succeeded because `creditBalance` was still positive.

2. **`reserveCredits` only checked balance.** `compact()` zeros expired grants on `ensureLoaded` and at the end of each write, so between the deadline passing and the next write the cached `creditBalance` still looked spendable. The first request after expiry slipped through and debited a stale grant.

## Changes

- `src/lib/store/billing-store.ts`
  - Add `findAccount(accountID)` helper.
  - `reserveCredits` rejects with 402 when `account.state !== "active"` or `account.creditExpiresAt <= now`, before consulting balance.
- `src/lib/auth/bearer.ts`
  - The `rk_...` path now requires `account.state === "active"` in addition to `key.state === "active"`. Mismatch returns null → caller responds 401.
  - The env / rotating admin-bearer path is unchanged.
- `tests/unit/billing-gates.test.ts` (new, 7 tests)

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npx vitest run` — 197/197 tests pass (29 files), incl. the 7 new ones
- [ ] Sanity-check on a staging relay that an admin pausing an account flips inbound traffic to 401 within one request

https://claude.ai/code/session_018pBoynBC6wHwTB2nxuXqPW

---
_Generated by [Claude Code](https://claude.ai/code/session_018pBoynBC6wHwTB2nxuXqPW)_