### PR TITLE
Use Opus 4.7 with max thinking for code review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,7 +39,8 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          claude_args: '--model claude-opus-4-7'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} ultrathink'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary
- Switch `Claude Code Review` workflow to `claude-opus-4-7` via `claude_args: --model claude-opus-4-7`
- Append `ultrathink` to the slash-command prompt so reviews use the maximum thinking budget

## Test plan
- [ ] Open/sync a PR and confirm the `Claude Code Review` job logs `model: claude-opus-4-7`
- [ ] Verify the review still completes successfully (no auth/model errors)

https://claude.ai/code/session_01EUsenLr2nQHpe36S1NfoiG

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUsenLr2nQHpe36S1NfoiG)_