### PR TITLE
fix(relay): load Google Fonts via &lt;link&gt; so Material Symbols actually render

### DIFF
--- a/relay/src/app/globals.css
+++ b/relay/src/app/globals.css
@@ -4,9 +4,9 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Material Symbols Rounded — loaded from Google Fonts. Falls back silently
-   if the network blocks it; icon glyphs degrade to text. */
-@import url("https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,400,0,0&family=Roboto+Flex:opsz,wght@8..144,300..700&family=Roboto+Mono:wght@400;500&family=Noto+Sans+SC:wght@400;500;700&display=swap");
+/* Google Fonts (Material Symbols Rounded, Roboto Flex/Mono, Noto Sans SC) are
+   loaded via <link> in src/app/layout.tsx — a CSS @import here would land
+   after the @tailwind expansions and the browser would silently drop it. */
 
 @layer base {
   html,

--- a/relay/src/app/layout.tsx
+++ b/relay/src/app/layout.tsx
@@ -11,6 +11,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="zh-Hans" suppressHydrationWarning>
       <head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
+        <link
+          rel="stylesheet"
+          href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,400,0,0&family=Roboto+Flex:opsz,wght@8..144,300..700&family=Roboto+Mono:wght@400;500&family=Noto+Sans+SC:wght@400;500;700&display=swap"
+        />
         <script
           // Read stored theme before hydration to avoid flash.
           dangerouslySetInnerHTML={{


### PR DESCRIPTION
## Summary

Every icon in the relay admin UI was rendering as the literal icon name (e.g. the bare text `check_circle`, `flag`, `hub`, `arrow_forward`) instead of a glyph.

**Root cause:** in `relay/src/app/globals.css`, the Google Fonts stylesheet was loaded with `@import url("https://fonts.googleapis.com/...")` placed **after** the `@tailwind base/components/utilities` directives. Per the CSS spec, `@import` rules must appear before any style rules — once Tailwind expands those directives during build, the import lands after style rules in the final stylesheet and the browser silently drops it. The Material Symbols Rounded font therefore never loaded, and the `<Icon>` component (`relay/src/components/m3/icon.tsx`), which relies on the font's ligature substitution to turn the icon name into a glyph, fell through to plain text.

**Fix:** load the Google Fonts stylesheet from a `<link rel="stylesheet">` in the root layout's `<head>` (with `preconnect` hints), and leave a comment in `globals.css` so the trap isn't reintroduced.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes (Next.js standalone)
- [x] `npm run test` — all 197 tests pass
- [x] Deployed to `ai.origenclub.cn`; `/api/health` returns 200; the rendered `/login` HTML now contains the `fonts.googleapis.com/.../Material+Symbols+Rounded` `<link>`
- [ ] Visual confirmation in browser that icons (sidebar nav, launch checklist, KPI cards) render as glyphs

https://claude.ai/code/session_01TMj7EjpbZwxaEpb6ufR72Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMj7EjpbZwxaEpb6ufR72Q)_